### PR TITLE
Query method to get mission model resource value schema

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -18,6 +18,7 @@ from .schemas.client import CommandDictionaryInfo
 from .schemas.client import ExpansionRun
 from .schemas.client import ExpansionRule
 from .schemas.client import ExpansionSet
+from .schemas.client import ResourceType
 from .utils.serialization import postgres_duration_to_microseconds
 from .aerie_host import AerieHostSession
 
@@ -1547,3 +1548,30 @@ class AerieClient:
         resp = self.host_session.post_to_graphql(get_violations_query, plan_id=plan_id)
         return resp["constraintViolations"]
 
+    def get_resource_types(self, model_id: int) -> List[ResourceType]:
+        """Get resource types (value schema)
+
+        Get the type information for each resource in a mission model.
+
+        The schema format is described in the Aerie documentation [here](https://nasa-ammos.github.io/aerie-docs/mission-modeling/advanced-value-schemas/#value-schemas-in-json).
+
+        Args:
+            model_id (int): Mission model for resources
+
+        Returns:
+            List[ResourceType]
+        """
+
+        get_resource_types_query = """
+        query ResourceTypes($missionModelId: ID!) {
+            resourceTypes(missionModelId: $missionModelId) {
+                name
+                schema
+            }
+        }
+        """
+
+        resp = self.host_session.post_to_graphql(
+            get_resource_types_query, missionModelId=model_id
+        )
+        return [ResourceType.from_dict(r) for r in resp]

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -277,3 +277,10 @@ class ExpansionRule:
     authoring_mission_model_id: int
     authoring_command_dict_id: int
     expansion_logic: Optional[str] = None
+
+
+@dataclass_json
+@dataclass
+class ResourceType:
+    name: str
+    schema: Dict

--- a/tests/files/mock_responses/get_resource_types.json
+++ b/tests/files/mock_responses/get_resource_types.json
@@ -42,6 +42,39 @@
                     },
                     "type": "struct"
                 }
+            },
+            {
+                "name": "/data/arbitrarilyComplex",
+                "schema": {
+                    "items": {
+                        "items": {
+                            "stringProperty": {
+                                "type": "string"
+                            },
+                            "enumProperty": {
+                                "type": "variant",
+                                "variants": [
+                                    {
+                                        "key": "A",
+                                        "label": "A"
+                                    },
+                                    {
+                                        "key": "B",
+                                        "label": "B"
+                                    }
+                                ]
+                            },
+                            "intProperty": {
+                                "type": "int"
+                            },
+                            "booleanProperty": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "struct"
+                    },
+                    "type": "series"
+                }
             }
         ]
     }

--- a/tests/files/mock_responses/get_resource_types.json
+++ b/tests/files/mock_responses/get_resource_types.json
@@ -1,0 +1,48 @@
+[
+    {
+        "request": {
+            "query": "query ResourceTypes($missionModelId: ID!) { resourceTypes(missionModelId: $missionModelId) { name schema } }",
+            "variables": {
+                "missionModelId": 1
+            }
+        },
+        "response": [
+            {
+                "name": "/imager/dataRate",
+                "schema": {
+                    "type": "real"
+                }
+            },
+            {
+                "name": "/imager/hardwareState",
+                "schema": {
+                    "type": "variant",
+                    "variants": [
+                        {
+                            "key": "OFF",
+                            "label": "OFF"
+                        },
+                        {
+                            "key": "ON",
+                            "label": "ON"
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "/data/dataVolume",
+                "schema": {
+                    "items": {
+                        "initial": {
+                            "type": "real"
+                        },
+                        "rate": {
+                            "type": "real"
+                        }
+                    },
+                    "type": "struct"
+                }
+            }
+        ]
+    }
+]

--- a/tests/test_aerie_client.py
+++ b/tests/test_aerie_client.py
@@ -10,6 +10,7 @@ from aerie_cli.aerie_host import AerieHostSession
 from aerie_cli.schemas.client import ActivityCreate
 from aerie_cli.schemas.api import ApiActivityPlanRead
 from aerie_cli.schemas.client import ActivityPlanRead
+from aerie_cli.schemas.client import ResourceType
 
 BLANK_LINE_REGEX = r'^\s*$'
 EXPECTED_RESULTS_DIRECTORY = Path(
@@ -171,4 +172,32 @@ def test_get_resource_samples():
 
     res = client.get_resource_samples(1, ["hardwareState"])
     print(json.dumps(res, indent=2))
+    assert res == expected
+
+def test_get_resource_types():
+    host_session = MockAerieHostSession("get_resource_types")
+    client = AerieClient(host_session)
+
+    expected = [
+        ResourceType("/imager/dataRate", {"type": "real"}),
+        ResourceType(
+            "/imager/hardwareState",
+            {
+                "type": "variant",
+                "variants": [
+                    {"key": "OFF", "label": "OFF"},
+                    {"key": "ON", "label": "ON"},
+                ],
+            },
+        ),
+        ResourceType(
+            "/data/dataVolume",
+            {
+                "items": {"initial": {"type": "real"}, "rate": {"type": "real"}},
+                "type": "struct",
+            },
+        ),
+    ]
+
+    res = client.get_resource_types(1)
     assert res == expected

--- a/tests/test_aerie_client.py
+++ b/tests/test_aerie_client.py
@@ -174,6 +174,7 @@ def test_get_resource_samples():
     print(json.dumps(res, indent=2))
     assert res == expected
 
+
 def test_get_resource_types():
     host_session = MockAerieHostSession("get_resource_types")
     client = AerieClient(host_session)
@@ -195,6 +196,27 @@ def test_get_resource_types():
             {
                 "items": {"initial": {"type": "real"}, "rate": {"type": "real"}},
                 "type": "struct",
+            },
+        ),
+        ResourceType(
+            "/data/arbitrarilyComplex",
+            {
+                "items": {
+                    "items": {
+                        "stringProperty": {"type": "string"},
+                        "enumProperty": {
+                            "type": "variant",
+                            "variants": [
+                                {"key": "A", "label": "A"},
+                                {"key": "B", "label": "B"},
+                            ],
+                        },
+                        "intProperty": {"type": "int"},
+                        "booleanProperty": {"type": "boolean"},
+                    },
+                    "type": "struct",
+                },
+                "type": "series",
             },
         ),
     ]


### PR DESCRIPTION
Adds a query method + test for getting resource value schema. As implemented, the schema is just stored as a Python dictionary on the `ResourceType` dataclass for simplicity; this could be branched out into more advanced dataclasses based on the Aerie value schema combinatory types if the need arises.

Closes #4 with the caveat that this doesn't explicitly get enumerations; I left that out because the combinatory schema preclude simply getting enumerated ("variant") values for a given resource. 