### PR TITLE
Support Activity Anchoring + Refactoring/Improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/src/aerie_cli/schemas/api.py
+++ b/src/aerie_cli/schemas/api.py
@@ -11,7 +11,6 @@ from dataclasses_json import config
 from dataclasses_json import dataclass_json
 from dataclasses_json import LetterCase
 
-from ..utils.serialization import postgres_duration_to_timedelta
 from ..utils.serialization import postgres_interval_to_timedelta
 from ..utils.serialization import timedelta_to_postgres_interval
 
@@ -80,7 +79,9 @@ class ApiActivityPlanRead(ApiActivityPlanBase):
     id: int
     simulations: list[int]
     duration: timedelta = field(
-        metadata=config(decoder=postgres_duration_to_timedelta, encoder=timedelta.__str__)
+        metadata=config(
+            decoder=postgres_interval_to_timedelta, encoder=timedelta.__str__
+        )
     )
     activity_directives: Optional[List[ApiActivityRead]] = None
 

--- a/src/aerie_cli/schemas/api.py
+++ b/src/aerie_cli/schemas/api.py
@@ -18,8 +18,8 @@ from dataclasses_json import config
 from dataclasses_json import dataclass_json
 from dataclasses_json import LetterCase
 
-from ..utils.serialization import postgres_interval_to_timedelta
-from ..utils.serialization import timedelta_to_postgres_interval
+from aerie_cli.utils.serialization import postgres_interval_to_timedelta
+from aerie_cli.utils.serialization import timedelta_to_postgres_interval
 
 
 @dataclass_json

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -16,7 +16,7 @@ from arrow import Arrow
 from dataclasses_json import config
 from dataclasses_json import dataclass_json
 
-from ..utils.serialization import postgres_interval_to_timedelta
+from ..utils.serialization import parse_timedelta_str
 from .api import ApiActivityCreate
 from .api import ApiActivityPlanCreate
 from .api import ApiActivityPlanRead
@@ -38,7 +38,7 @@ class Activity(ActivityBase):
     """
     start_offset: timedelta = field(
         metadata=config(
-            decoder=postgres_interval_to_timedelta,
+            decoder=parse_timedelta_str,
             encoder=timedelta.__str__
         )
     )
@@ -180,7 +180,7 @@ class AsSimulatedActivity:
     )
     children: list[str]
     duration: timedelta = field(
-        metadata=config(decoder=postgres_interval_to_timedelta,
+        metadata=config(decoder=parse_timedelta_str,
                         encoder=timedelta.__str__)
     )
     parameters: dict[str, Any]

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -11,7 +11,7 @@ from arrow import Arrow
 from dataclasses_json import config
 from dataclasses_json import dataclass_json
 
-from ..utils.serialization import postgres_duration_to_timedelta
+from ..utils.serialization import postgres_interval_to_timedelta
 from .api import ApiActivityCreate
 from .api import ApiActivityPlanCreate
 from .api import ApiActivityPlanRead
@@ -146,7 +146,7 @@ class AsSimulatedActivity:
     )
     children: list[str]
     duration: timedelta = field(
-        metadata=config(decoder=postgres_duration_to_timedelta,
+        metadata=config(decoder=postgres_interval_to_timedelta,
                         encoder=timedelta.__str__)
     )
     parameters: dict[str, Any]

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -16,16 +16,16 @@ from arrow import Arrow
 from dataclasses_json import config
 from dataclasses_json import dataclass_json
 
-from ..utils.serialization import parse_timedelta_str
-from .api import ApiActivityCreate
-from .api import ApiActivityPlanCreate
-from .api import ApiActivityPlanRead
-from .api import ApiActivityRead
-from .api import ApiAsSimulatedActivity
-from .api import ApiResourceSampleResults
-from .api import ApiSimulatedResourceSample
-from .api import ApiSimulationResults
-from .api import ActivityBase
+from aerie_cli.utils.serialization import parse_timedelta_str
+from aerie_cli.schemas.api import ApiActivityCreate
+from aerie_cli.schemas.api import ApiActivityPlanCreate
+from aerie_cli.schemas.api import ApiActivityPlanRead
+from aerie_cli.schemas.api import ApiActivityRead
+from aerie_cli.schemas.api import ApiAsSimulatedActivity
+from aerie_cli.schemas.api import ApiResourceSampleResults
+from aerie_cli.schemas.api import ApiSimulatedResourceSample
+from aerie_cli.schemas.api import ApiSimulationResults
+from aerie_cli.schemas.api import ActivityBase
 
 
 @dataclass_json

--- a/src/aerie_cli/utils/serialization.py
+++ b/src/aerie_cli/utils/serialization.py
@@ -86,8 +86,33 @@ def postgres_interval_to_microseconds(interval: str) -> int:
 
 
 def timedelta_to_postgres_interval(td: timedelta) -> str:
-    """Constructs a PostgreSQL interval from a `timedelta`
-    """
+    """Constructs a PostgreSQL interval from a `timedelta`"""
     seconds = td.days * 86400 + td.seconds
     microseconds = td.microseconds
     return f"{int(seconds)} seconds {int(microseconds)} microseconds"
+
+
+def parse_timedelta_str(td_string: str) -> timedelta:
+    """Parse the string format returned by timedelta.__str__"""
+    pattern = r"((?P<days>[-+]?\d+)\s*day[s]?,\s*)?(?P<hours>\d{1,2}):(?P<minutes>\d{2}):(?P<seconds>\d{2})(?:\.(?P<microseconds>\d{6}))?"
+    match = re.match(pattern, td_string)
+
+    if match:
+        groups = match.groupdict()
+        days = int(groups["days"]) if groups["days"] else 0
+        hours = int(groups["hours"])
+        minutes = int(groups["minutes"])
+        seconds = int(groups["seconds"])
+        microseconds = int(groups["microseconds"]) if groups["microseconds"] else 0
+
+        parsed_timedelta = timedelta(
+            days=days,
+            hours=hours,
+            minutes=minutes,
+            seconds=seconds,
+            microseconds=microseconds,
+        )
+        return parsed_timedelta
+
+    else:
+        raise ValueError(f"Invalid time string format: {td_string}")

--- a/src/aerie_cli/utils/serialization.py
+++ b/src/aerie_cli/utils/serialization.py
@@ -1,41 +1,93 @@
-import math
+"""Aerie object (de)serialization utilities
+
+Postgres interval parsing modified from Django implementation:
+https://github.com/django/django/blob/0dd29209091280ccf34e07c9468746c396b7778e/django/utils/dateparse.py#L52-L64
+
+Django is licensed under the BSD 3-Clause License:
+    Copyright (c) Django Software Foundation and individual contributors.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of Django nor the names of its contributors may be used
+        to endorse or promote products derived from this software without
+        specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
 import re
 from datetime import timedelta
 
 
-POSTGRES_INTERVAL_PATTERN = re.compile(
-    r"(?P<seconds>\d+)\sseconds\s(?P<milliseconds>\d+)\smilliseconds"
+POSTGRES_INTERVAL_RE = re.compile(
+    r"^"
+    r"(?:(?P<days>-?\d+) (days? ?))?"
+    r"(?:(?P<sign>[-+])?"
+    r"(?P<hours>\d+):"
+    r"(?P<minutes>\d\d):"
+    r"(?P<seconds>\d\d)"
+    r"(?:\.(?P<microseconds>\d{1,6}))?"
+    r")?$"
 )
 
 
-def postgres_duration_to_timedelta(hms_string: str) -> timedelta:
-    if ":" not in hms_string:
-        hms_string += " 00:00:00"
-    if 'days' in hms_string:
-        days, hms_string = hms_string.split(' days ')
-    elif 'day' in hms_string:
-        days, hms_string = hms_string.split(' day ')
-    else:
-        days = 0
-    hours, minutes, seconds = hms_string.split(":")
-    return timedelta(days=int(days), hours=int(hours), minutes=int(minutes), seconds=float(seconds))
-
-
-def postgres_duration_to_microseconds(hms_string: str) -> int:
-    return int(round(postgres_duration_to_timedelta(hms_string).total_seconds() * (10**6)))
-
-
-def timedelta_to_postgres_interval(delta: timedelta) -> str:
-    """Constructs a PostgresQL interval from two datetimes."""
-    (seconds, partial_seconds) = divmod(delta.total_seconds(), 1)
-    # what is appropriate rounding method?
-    milliseconds = math.floor(partial_seconds * 1000)
-    return f"{int(seconds)} seconds {milliseconds} milliseconds"
-
-
 def postgres_interval_to_timedelta(interval: str) -> timedelta:
-    """Constructs a timedelta from a PostgresQL interval string."""
-    match = POSTGRES_INTERVAL_PATTERN.match(interval)
-    return timedelta(
-        seconds=match.group("seconds"), milliseconds=match.group("milliseconds")
-    )
+    """Parse a Postgres inteval to a `timedelta` object
+
+    Modified from Django interval parsing cited above.
+
+    Args:
+        interval (str): Postgres interval string
+
+    Raises:
+        ValueError: Unable to match patterns in the interval
+
+    Returns:
+        timedelta
+    """
+    match = POSTGRES_INTERVAL_RE.match(interval)
+    if match:
+        kw = match.groupdict()
+        sign = -1 if kw.pop("sign", "+") == "-" else 1
+        if kw.get("microseconds"):
+            kw["microseconds"] = kw["microseconds"].ljust(6, "0")
+        kw = {k: float(v.replace(",", ".")) for k, v in kw.items() if v is not None}
+        days = timedelta(kw.pop("days", 0.0) or 0.0)
+        return days + sign * timedelta(**kw)
+    else:
+        raise ValueError(f"Unable to parse interval string: {interval}")
+
+
+def postgres_interval_to_microseconds(interval: str) -> int:
+    """Convert a postgres interval string to an integer number of microseconds
+
+    Both `timedelta` and Postgres intervals have a precision of 1us, so this conversion shouldn't introduce any rounding errors
+    """
+    return int(postgres_interval_to_timedelta(interval).total_seconds() * (10**6))
+
+
+def timedelta_to_postgres_interval(td: timedelta) -> str:
+    """Constructs a PostgreSQL interval from a `timedelta`
+    """
+    seconds = td.days * 86400 + td.seconds
+    microseconds = td.microseconds
+    return f"{int(seconds)} seconds {int(microseconds)} microseconds"

--- a/tests/unit_tests/files/expected_results/get_activity_plan_by_id.json
+++ b/tests/unit_tests/files/expected_results/get_activity_plan_by_id.json
@@ -1,0 +1,48 @@
+{
+  "name": "example-plan",
+  "start_time": "2030-01-01T00:00:00+00:00",
+  "end_time": "2030-01-01T12:00:00+00:00",
+  "id": 1,
+  "model_id": 1,
+  "sim_id": 1,
+  "activities": [
+    {
+      "type": "ACT_One",
+      "start_offset": "0:00:00",
+      "tags": [
+        "first_tag",
+        "second_tag"
+      ],
+      "metadata": {},
+      "name": "Anchor",
+      "arguments": {},
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "id": 1
+    },
+    {
+      "type": "ACT_Two",
+      "start_offset": "2:00:00",
+      "tags": [],
+      "metadata": {},
+      "name": "Anchored_to_start",
+      "arguments": {},
+      "anchor_id": 1,
+      "anchored_to_start": true,
+      "id": 2
+    },
+    {
+      "type": "ACT_Three",
+      "start_offset": "4:00:00",
+      "tags": [],
+      "metadata": {},
+      "name": "Anchored_to_end",
+      "arguments": {
+        "test": "test"
+      },
+      "anchor_id": 1,
+      "anchored_to_start": false,
+      "id": 3
+    }
+  ]
+}

--- a/tests/unit_tests/files/inputs/create_activity_plan_1.json
+++ b/tests/unit_tests/files/inputs/create_activity_plan_1.json
@@ -1,0 +1,48 @@
+{
+  "name": "upload-test-1",
+  "start_time": "2030-01-01T00:00:00+00:00",
+  "end_time": "2030-01-01T12:00:00+00:00",
+  "id": 123,
+  "model_id": 7,
+  "sim_id": 321,
+  "activities": [
+    {
+      "type": "ACT_One",
+      "arguments": {},
+      "name": "Anchor",
+      "tags": [
+        "first_tag",
+        "second_tag"
+      ],
+      "metadata": {},
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "start_offset": "0:00:00",
+      "id": 1
+    },
+    {
+      "type": "ACT_Two",
+      "arguments": {},
+      "name": "Anchored_to_start",
+      "tags": [],
+      "metadata": {},
+      "anchor_id": 1,
+      "anchored_to_start": true,
+      "start_offset": "2:00:00",
+      "id": 2
+    },
+    {
+      "type": "ACT_Three",
+      "arguments": {
+        "test": "test"
+      },
+      "name": "Anchored_to_end",
+      "tags": [],
+      "metadata": {},
+      "anchor_id": 1,
+      "anchored_to_start": false,
+      "start_offset": "4:00:00",
+      "id": 3
+    }
+  ]
+}

--- a/tests/unit_tests/files/inputs/create_activity_plan_2.json
+++ b/tests/unit_tests/files/inputs/create_activity_plan_2.json
@@ -1,0 +1,48 @@
+{
+    "name": "upload-test-2",
+    "start_time": "2030-01-01T00:00:00+00:00",
+    "end_time": "2030-01-01T12:00:00+00:00",
+    "id": 123,
+    "model_id": 7,
+    "sim_id": 321,
+    "activities": [
+      {
+        "type": "ACT_One",
+        "arguments": {},
+        "name": "Anchored_1",
+        "tags": [
+          "first_tag",
+          "second_tag"
+        ],
+        "metadata": {},
+        "anchor_id": 2,
+        "anchored_to_start": true,
+        "start_offset": "-1:00:00",
+        "id": 1
+      },
+      {
+        "type": "ACT_Two",
+        "arguments": {},
+        "name": "Anchor",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": null,
+        "anchored_to_start": true,
+        "start_offset": "2:00:00",
+        "id": 2
+      },
+      {
+        "type": "ACT_Three",
+        "arguments": {
+          "test": "test"
+        },
+        "name": "Anchored_2",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": 1,
+        "anchored_to_start": false,
+        "start_offset": "4:00:00",
+        "id": 3
+      }
+    ]
+  }

--- a/tests/unit_tests/files/inputs/create_activity_plan_2.json
+++ b/tests/unit_tests/files/inputs/create_activity_plan_2.json
@@ -17,7 +17,7 @@
         "metadata": {},
         "anchor_id": 2,
         "anchored_to_start": true,
-        "start_offset": "-1:00:00",
+        "start_offset": "-1 day, 23:00:00",
         "id": 1
       },
       {

--- a/tests/unit_tests/files/inputs/get_activity_start_time.json
+++ b/tests/unit_tests/files/inputs/get_activity_start_time.json
@@ -1,0 +1,87 @@
+{
+    "name": "get-activity-start-time",
+    "start_time": "2030-01-01T00:00:00+00:00",
+    "end_time": "2030-01-01T12:00:00+00:00",
+    "id": 1,
+    "model_id": 1,
+    "sim_id": 1,
+    "activities": [
+      {
+        "type": "ACT_One",
+        "arguments": {},
+        "name": "Anchored_1",
+        "tags": [
+          "first_tag",
+          "second_tag"
+        ],
+        "metadata": {},
+        "anchor_id": 2,
+        "anchored_to_start": true,
+        "start_offset": "-1:00:00",
+        "id": 1
+      },
+      {
+        "type": "ACT_Two",
+        "arguments": {},
+        "name": "Anchored_to_plan_start",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": null,
+        "anchored_to_start": true,
+        "start_offset": "2:00:00",
+        "id": 2
+      },
+      {
+        "type": "ACT_Three",
+        "arguments": {
+          "test": "test"
+        },
+        "name": "Anchored_2_to_end",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": 1,
+        "anchored_to_start": false,
+        "start_offset": "4:00:00",
+        "id": 3
+      },
+      {
+        "type": "ACT_Four",
+        "arguments": {
+          "test": "test"
+        },
+        "name": "Anchored_2_to_start",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": 1,
+        "anchored_to_start": true,
+        "start_offset": "6:00:00",
+        "id": 4
+      },
+      {
+        "type": "ACT_Five",
+        "arguments": {
+          "test": "test"
+        },
+        "name": "Ancored_to_plan_end",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": null,
+        "anchored_to_start": false,
+        "start_offset": "-6:00:00",
+        "id": 5
+      },
+      {
+        "type": "ACT_Six",
+        "arguments": {
+          "test": "test"
+        },
+        "name": "Anchor_no_existo",
+        "tags": [],
+        "metadata": {},
+        "anchor_id": 123,
+        "anchored_to_start": true,
+        "start_offset": "2:00:00",
+        "id": 6
+      }
+    ]
+  }

--- a/tests/unit_tests/files/inputs/get_activity_start_time.json
+++ b/tests/unit_tests/files/inputs/get_activity_start_time.json
@@ -17,7 +17,7 @@
         "metadata": {},
         "anchor_id": 2,
         "anchored_to_start": true,
-        "start_offset": "-1:00:00",
+        "start_offset": "-1 day, 23:00:00",
         "id": 1
       },
       {
@@ -67,7 +67,7 @@
         "metadata": {},
         "anchor_id": null,
         "anchored_to_start": false,
-        "start_offset": "-6:00:00",
+        "start_offset": "-1 day, 18:00:00",
         "id": 5
       },
       {

--- a/tests/unit_tests/files/mock_responses/create_activity.json
+++ b/tests/unit_tests/files/mock_responses/create_activity.json
@@ -5,14 +5,16 @@
             "variables": {
                 "activity": {
                     "type": "NoOp",
+                    "start_offset": "0 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "My Activity",
                     "arguments": {
                         "aParameter": "2030-001T00:00:00Z"
                     },
-                    "name": "My Activity",
-                    "tags": "{}",
-                    "metadata": {},
-                    "plan_id": 1,
-                    "start_offset": "0 seconds 0 milliseconds"
+                    "anchor_id": null,
+                    "anchored_to_start": true,
+                    "plan_id": 1
                 }
             }
         },

--- a/tests/unit_tests/files/mock_responses/create_activity_plan_1.json
+++ b/tests/unit_tests/files/mock_responses/create_activity_plan_1.json
@@ -1,0 +1,115 @@
+[
+    {
+        "request": {
+            "query": "mutation CreatePlan($plan: plan_insert_input!) { createPlan: insert_plan_one(object: $plan) { id revision } }",
+            "variables": {
+                "plan": {
+                    "model_id": 7,
+                    "name": "upload-test-1",
+                    "start_time": "2030-01-01T00:00:00+00:00",
+                    "duration": "43200 seconds 0 microseconds"
+                }
+            }
+        },
+        "response": {
+            "id": 456,
+            "revision": 0
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_One",
+                    "start_offset": "0 seconds 0 microseconds",
+                    "tags": "{first_tag,second_tag}",
+                    "metadata": {},
+                    "name": "Anchor",
+                    "arguments": {},
+                    "anchor_id": null,
+                    "anchored_to_start": true,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 626
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_Three",
+                    "start_offset": "14400 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "Anchored_to_end",
+                    "arguments": {
+                        "test": "test"
+                    },
+                    "anchor_id": 626,
+                    "anchored_to_start": false,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 627
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_Two",
+                    "start_offset": "7200 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "Anchored_to_start",
+                    "arguments": {},
+                    "anchor_id": 626,
+                    "anchored_to_start": true,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 628
+        }
+    },
+    {
+        "request": {
+            "query": "mutation updateSimulationBounds($plan_id: Int!, $simulation_start_time: timestamptz!, $simulation_end_time: timestamptz!) { update_simulation( where: {plan_id: {_eq: $plan_id}}, _set: { simulation_start_time: $simulation_start_time, simulation_end_time: $simulation_end_time } ){ affected_rows } }",
+            "variables": {
+                "plan_id": 456,
+                "simulation_start_time": "2030-01-01T00:00:00+00:00",
+                "simulation_end_time": "2030-01-01T12:00:00+00:00"
+            }
+        },
+        "response": {
+            "id": 678
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateSchedulingSpec($spec: scheduling_specification_insert_input!) { insert_scheduling_specification_one(object: $spec) { id } }",
+            "variables": {
+                "spec": {
+                    "plan_id": 456,
+                    "analysis_only": false,
+                    "horizon_end": "2030-01-01T12:00:00+00:00",
+                    "horizon_start": "2030-01-01T00:00:00+00:00",
+                    "plan_revision": 0,
+                    "simulation_arguments": {}
+                }
+            }
+        },
+        "response": {
+            "id": 789
+        }
+    }
+]

--- a/tests/unit_tests/files/mock_responses/create_activity_plan_2.json
+++ b/tests/unit_tests/files/mock_responses/create_activity_plan_2.json
@@ -1,0 +1,115 @@
+[
+    {
+        "request": {
+            "query": "mutation CreatePlan($plan: plan_insert_input!) { createPlan: insert_plan_one(object: $plan) { id revision } }",
+            "variables": {
+                "plan": {
+                    "model_id": 7,
+                    "name": "upload-test-2",
+                    "start_time": "2030-01-01T00:00:00+00:00",
+                    "duration": "43200 seconds 0 microseconds"
+                }
+            }
+        },
+        "response": {
+            "id": 456,
+            "revision": 0
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_Two",
+                    "start_offset": "7200 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "Anchor",
+                    "arguments": {},
+                    "anchor_id": null,
+                    "anchored_to_start": true,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 629
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_One",
+                    "start_offset": "-3600 seconds 0 microseconds",
+                    "tags": "{first_tag,second_tag}",
+                    "metadata": {},
+                    "name": "Anchored_1",
+                    "arguments": {},
+                    "anchor_id": 629,
+                    "anchored_to_start": true,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 630
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateActivity($activity: activity_directive_insert_input!) { createActivity: insert_activity_directive_one(object: $activity) { id } }",
+            "variables": {
+                "activity": {
+                    "type": "ACT_Three",
+                    "start_offset": "14400 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "Anchored_2",
+                    "arguments": {
+                        "test": "test"
+                    },
+                    "anchor_id": 630,
+                    "anchored_to_start": false,
+                    "plan_id": 456
+                }
+            }
+        },
+        "response": {
+            "id": 631
+        }
+    },
+    {
+        "request": {
+            "query": "mutation updateSimulationBounds($plan_id: Int!, $simulation_start_time: timestamptz!, $simulation_end_time: timestamptz!) { update_simulation( where: {plan_id: {_eq: $plan_id}}, _set: { simulation_start_time: $simulation_start_time, simulation_end_time: $simulation_end_time } ){ affected_rows } }",
+            "variables": {
+                "plan_id": 456,
+                "simulation_start_time": "2030-01-01T00:00:00+00:00",
+                "simulation_end_time": "2030-01-01T12:00:00+00:00"
+            }
+        },
+        "response": {
+            "id": 58
+        }
+    },
+    {
+        "request": {
+            "query": "mutation CreateSchedulingSpec($spec: scheduling_specification_insert_input!) { insert_scheduling_specification_one(object: $spec) { id } }",
+            "variables": {
+                "spec": {
+                    "plan_id": 456,
+                    "analysis_only": false,
+                    "horizon_end": "2030-01-01T12:00:00+00:00",
+                    "horizon_start": "2030-01-01T00:00:00+00:00",
+                    "plan_revision": 0,
+                    "simulation_arguments": {}
+                }
+            }
+        },
+        "response": {
+            "id": 58
+        }
+    }
+]

--- a/tests/unit_tests/files/mock_responses/get_activity_plan_by_id.json
+++ b/tests/unit_tests/files/mock_responses/get_activity_plan_by_id.json
@@ -1,0 +1,62 @@
+[
+    {
+        "request": {
+            "query": "query get_plans ($plan_id: Int!) { plan_by_pk(id: $plan_id) { id model_id name start_time duration simulations{ id } activity_directives(order_by: { start_offset: asc }) { id name type start_offset arguments metadata tags anchor_id anchored_to_start } } }",
+            "variables": {
+                "plan_id": 1
+            }
+        },
+        "response": {
+            "id": 1,
+            "model_id": 1,
+            "name": "example-plan",
+            "start_time": "2030-01-01T00:00:00+00:00",
+            "duration": "12:00:00",
+            "simulations": [
+                {
+                    "id": 1
+                }
+            ],
+            "activity_directives": [
+                {
+                    "id": 1,
+                    "name": "Anchor",
+                    "type": "ACT_One",
+                    "start_offset": "00:00:00",
+                    "arguments": {},
+                    "metadata": {},
+                    "tags": [
+                        "first_tag",
+                        "second_tag"
+                    ],
+                    "anchor_id": null,
+                    "anchored_to_start": true
+                },
+                {
+                    "id": 2,
+                    "name": "Anchored_to_start",
+                    "type": "ACT_Two",
+                    "start_offset": "02:00:00",
+                    "arguments": {},
+                    "metadata": {},
+                    "tags": [],
+                    "anchor_id": 1,
+                    "anchored_to_start": true
+                },
+                {
+                    "id": 3,
+                    "name": "Anchored_to_end",
+                    "type": "ACT_Three",
+                    "start_offset": "04:00:00",
+                    "arguments": {
+                        "test": "test"
+                    },
+                    "metadata": {},
+                    "tags": [],
+                    "anchor_id": 1,
+                    "anchored_to_start": false
+                }
+            ]
+        }
+    }
+]

--- a/tests/unit_tests/files/mock_responses/update_activity.json
+++ b/tests/unit_tests/files/mock_responses/update_activity.json
@@ -7,14 +7,16 @@
                 "plan_id": 1,
                 "activity": {
                     "type": "NoOp",
+                    "start_offset": "0 seconds 0 microseconds",
+                    "tags": "{}",
+                    "metadata": {},
+                    "name": "My Activity",
                     "arguments": {
                         "aParameter": "2030-001T00:00:00Z"
                     },
-                    "name": "My Activity",
-                    "tags": "{}",
-                    "metadata": {},
-                    "plan_id": 1,
-                    "start_offset": "0 seconds 0 milliseconds"
+                    "anchor_id": null,
+                    "anchored_to_start": true,
+                    "plan_id": 1
                 }
             }
         },

--- a/tests/unit_tests/test_dataclasses.py
+++ b/tests/unit_tests/test_dataclasses.py
@@ -1,0 +1,38 @@
+"""Test dataclasses and associated methods
+"""
+
+from pathlib import Path
+import arrow
+
+from aerie_cli.schemas.client import ActivityPlanRead
+import pytest
+
+INPUTS_DIRECTORY = Path(__file__).parent.joinpath("files", "inputs")
+
+
+def test_get_activity_start_time():
+    with open(INPUTS_DIRECTORY.joinpath("get_activity_start_time.json"), "r") as fid:
+        plan: ActivityPlanRead = ActivityPlanRead.from_json(fid.read())
+
+    # Activity anchored to plan start
+    assert plan.get_activity_start_time(2) == arrow.get("2030-01-01T02:00:00+00:00")
+
+    # Activity anchored to plan end
+    assert plan.get_activity_start_time(5) == arrow.get("2030-01-01T06:00:00+00:00")
+
+    # 1-long chain of valid anchoring
+    assert plan.get_activity_start_time(1) == arrow.get("2030-01-01T01:00:00+00:00")
+
+    # 2-long chain of valid anchoring
+    assert plan.get_activity_start_time(4) == arrow.get("2030-01-01T07:00:00+00:00")
+
+    # Invalid: references anchor to activity end
+    with pytest.raises(ValueError):
+        plan.get_activity_start_time(3)
+
+    # Invalid: anchor doesn't exist
+    with pytest.raises(ValueError):
+        plan.get_activity_start_time(6)
+
+    # Pass activity instance instead of ID
+    assert plan.get_activity_start_time(plan.activities[1]) == arrow.get("2030-01-01T02:00:00+00:00")

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from datetime import timedelta
+
+import pytest
+
+from aerie_cli.utils.serialization import postgres_interval_to_microseconds
+from aerie_cli.utils.serialization import postgres_interval_to_timedelta
+from aerie_cli.utils.serialization import timedelta_to_postgres_interval
+
+
+@dataclass
+class ExampleDuration:
+    as_timedelta: timedelta
+    as_output_interval: str
+    as_input_interval: str
+    as_microseconds: int
+
+
+TEST_CASES = [
+    ExampleDuration(
+        as_timedelta=timedelta(seconds=1),
+        as_output_interval="00:00:01",
+        as_input_interval="1 seconds 0 microseconds",
+        as_microseconds=int(1e6),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(seconds=-1),
+        as_output_interval="-00:00:01",
+        as_input_interval="-1 seconds 0 microseconds",
+        as_microseconds=int(-1e6),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(days=1, seconds=1),
+        as_output_interval="1 day 00:00:01",
+        as_input_interval="86401 seconds 0 microseconds",
+        as_microseconds=int(1e6 * 86401),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(days=1, seconds=-1),
+        as_output_interval="23:59:59",
+        as_input_interval="86399 seconds 0 microseconds",
+        as_microseconds=int(1e6 * 86399),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(days=-1, seconds=1),
+        as_output_interval="-23:59:59",
+        as_input_interval="-86399 seconds 0 microseconds",
+        as_microseconds=int(-1e6 * 86399),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(days=-1, seconds=-1),
+        as_output_interval="-1 day -00:00:01",
+        as_input_interval="-86401 seconds 0 microseconds",
+        as_microseconds=int(-1e6 * 86401),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(seconds=1, microseconds=123),
+        as_output_interval="00:00:01.000123",
+        as_input_interval="1 seconds 123 microseconds",
+        as_microseconds=int(1e6 + 123),
+    ),
+    ExampleDuration(
+        as_timedelta=timedelta(seconds=1, milliseconds=123),
+        as_output_interval="00:00:01.123",
+        as_input_interval="1 seconds 123000 microseconds",
+        as_microseconds=int(1e6 + 123000),
+    ),
+]
+
+
+@pytest.mark.parametrize("example_duration", TEST_CASES)
+def test_postgres_interval_to_microseconds(example_duration: ExampleDuration):
+    assert (
+        postgres_interval_to_microseconds(example_duration.as_output_interval)
+        == example_duration.as_microseconds
+    )
+
+
+@pytest.mark.parametrize("example_duration", TEST_CASES)
+def test_postgres_interval_to_timedelta(example_duration: ExampleDuration):
+    assert (
+        postgres_interval_to_timedelta(example_duration.as_output_interval)
+        == example_duration.as_timedelta
+    )
+
+
+@pytest.mark.parametrize("example_duration", TEST_CASES)
+def test_timedelta_to_postgres_interval(example_duration: ExampleDuration):
+    assert (
+        timedelta_to_postgres_interval(example_duration.as_timedelta)
+        == example_duration.as_input_interval
+    )

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -6,63 +6,70 @@ import pytest
 from aerie_cli.utils.serialization import postgres_interval_to_microseconds
 from aerie_cli.utils.serialization import postgres_interval_to_timedelta
 from aerie_cli.utils.serialization import timedelta_to_postgres_interval
+from aerie_cli.utils.serialization import parse_timedelta_str
 
 
 @dataclass
 class ExampleDuration:
     as_timedelta: timedelta
-    as_output_interval: str
-    as_input_interval: str
+    as_postgres_output: str
+    as_postgres_input: str
     as_microseconds: int
 
 
 TEST_CASES = [
     ExampleDuration(
         as_timedelta=timedelta(seconds=1),
-        as_output_interval="00:00:01",
-        as_input_interval="1 seconds 0 microseconds",
+        as_postgres_output="00:00:01",
+        as_postgres_input="1 seconds 0 microseconds",
         as_microseconds=int(1e6),
     ),
     ExampleDuration(
         as_timedelta=timedelta(seconds=-1),
-        as_output_interval="-00:00:01",
-        as_input_interval="-1 seconds 0 microseconds",
+        as_postgres_output="-00:00:01",
+        as_postgres_input="-1 seconds 0 microseconds",
         as_microseconds=int(-1e6),
     ),
     ExampleDuration(
         as_timedelta=timedelta(days=1, seconds=1),
-        as_output_interval="1 day 00:00:01",
-        as_input_interval="86401 seconds 0 microseconds",
+        as_postgres_output="1 day 00:00:01",
+        as_postgres_input="86401 seconds 0 microseconds",
         as_microseconds=int(1e6 * 86401),
     ),
     ExampleDuration(
+        as_timedelta=timedelta(days=2, seconds=1),
+        as_postgres_output="2 day 00:00:01",
+        as_postgres_input="172801 seconds 0 microseconds",
+        as_microseconds=int(1e6 * 172801),
+    ),
+    ExampleDuration(
         as_timedelta=timedelta(days=1, seconds=-1),
-        as_output_interval="23:59:59",
-        as_input_interval="86399 seconds 0 microseconds",
+        as_postgres_output="23:59:59",
+        as_postgres_input="86399 seconds 0 microseconds",
         as_microseconds=int(1e6 * 86399),
     ),
     ExampleDuration(
         as_timedelta=timedelta(days=-1, seconds=1),
-        as_output_interval="-23:59:59",
-        as_input_interval="-86399 seconds 0 microseconds",
+        as_postgres_output="-23:59:59",
+        as_postgres_input="-86399 seconds 0 microseconds",
         as_microseconds=int(-1e6 * 86399),
     ),
     ExampleDuration(
         as_timedelta=timedelta(days=-1, seconds=-1),
-        as_output_interval="-1 day -00:00:01",
-        as_input_interval="-86401 seconds 0 microseconds",
+        as_postgres_output="-1 day -00:00:01",
+        as_postgres_input="-86401 seconds 0 microseconds",
         as_microseconds=int(-1e6 * 86401),
     ),
     ExampleDuration(
         as_timedelta=timedelta(seconds=1, microseconds=123),
-        as_output_interval="00:00:01.000123",
-        as_input_interval="1 seconds 123 microseconds",
+        as_postgres_output="00:00:01.000123",
+        as_postgres_input="1 seconds 123 microseconds",
         as_microseconds=int(1e6 + 123),
     ),
     ExampleDuration(
         as_timedelta=timedelta(seconds=1, milliseconds=123),
-        as_output_interval="00:00:01.123",
-        as_input_interval="1 seconds 123000 microseconds",
+        as_postgres_output="00:00:01.123",
+        as_postgres_input="1 seconds 123000 microseconds",
         as_microseconds=int(1e6 + 123000),
     ),
 ]
@@ -71,7 +78,7 @@ TEST_CASES = [
 @pytest.mark.parametrize("example_duration", TEST_CASES)
 def test_postgres_interval_to_microseconds(example_duration: ExampleDuration):
     assert (
-        postgres_interval_to_microseconds(example_duration.as_output_interval)
+        postgres_interval_to_microseconds(example_duration.as_postgres_output)
         == example_duration.as_microseconds
     )
 
@@ -79,7 +86,7 @@ def test_postgres_interval_to_microseconds(example_duration: ExampleDuration):
 @pytest.mark.parametrize("example_duration", TEST_CASES)
 def test_postgres_interval_to_timedelta(example_duration: ExampleDuration):
     assert (
-        postgres_interval_to_timedelta(example_duration.as_output_interval)
+        postgres_interval_to_timedelta(example_duration.as_postgres_output)
         == example_duration.as_timedelta
     )
 
@@ -88,5 +95,13 @@ def test_postgres_interval_to_timedelta(example_duration: ExampleDuration):
 def test_timedelta_to_postgres_interval(example_duration: ExampleDuration):
     assert (
         timedelta_to_postgres_interval(example_duration.as_timedelta)
-        == example_duration.as_input_interval
+        == example_duration.as_postgres_input
+    )
+
+
+@pytest.mark.parametrize("example_duration", TEST_CASES)
+def test_parse_timedelta_str(example_duration: ExampleDuration):
+    assert (
+        parse_timedelta_str(str(example_duration.as_timedelta))
+        == example_duration.as_timedelta
     )


### PR DESCRIPTION
Support activity anchoring by adding necessary fields on `Activity` data structures. The implications of this are that the previous logic to evaluate absolute start times is flawed and would couple values on `Activity` objects. 

Additionally, the addition of anchoring poses an issue for uploading plans because referenced anchor IDs need to be updated. A summary of this is captured [here](https://github.com/NASA-AMMOS/aerie/issues/836). 

Because of the scope of the necessary changes, I took this as an opportunity to refactor the activity dataclasses and remove the notion of a client-side "Create" class for activities.

Breaking changes:

- `ActivityRead` and `ActivityCreate` are now consolidated to `Activity`.
- The `Activity` field `parameters` has been deprecated in favor of `arguments`, which reflects the naming used in Aerie.
- Activities no longer are stored with a calculated absolute `start_time` field; instead, activities have a `start_offset` and fields `anchor_id` and `anchored_to_start` which reflect how activity timing is defined in Aerie. Evaluate the effective start time of an activity within a plan using `ActivityPlanRead.get_activity_start_time()`.
- The `AerieClient.create_activity()` and `Activity.to_api_create()` methods no longer require plan start time to be passed as a parameter.

Closes #1 
Closes #2 