### PR TITLE
update to support 1.4.0 plan upload

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -180,18 +180,26 @@ class AerieClient:
         )
         plan_id = plan_resp["id"]
         plan_revision = plan_resp["revision"]
-
-        create_simulation_mutation = """
-        mutation CreateSimulation($simulation: simulation_insert_input!) {
-            createSimulation: insert_simulation_one(object: $simulation) {
-                id
+        simulation_start_time = plan_to_create.start_time.isoformat()
+        simulation_end_time = plan_to_create.end_time.isoformat()
+        update_simulation_mutation = """
+        mutation updateSimulationBounds($plan_id: Int!, $simulation_start_time: timestamptz!, $simulation_end_time: timestamptz!) {
+            update_simulation(
+                where: {plan_id: {_eq: $plan_id}},
+                _set: {
+                    simulation_start_time: $simulation_start_time,
+                    simulation_end_time: $simulation_end_time
+                }
+            ){
+                affected_rows
             }
         }
         """
-        # TODO: determine how to handle arguments--should we accept another upload?
         _ = self.host_session.post_to_graphql(
-            create_simulation_mutation, simulation={
-                "arguments": {}, "plan_id": plan_id}
+            update_simulation_mutation,
+            plan_id=plan_id,
+            simulation_start_time=simulation_start_time,
+            simulation_end_time=simulation_end_time
         )
 
         # TODO: move to batch insert once we confirm that the Aerie bug is fixed'


### PR DESCRIPTION
Update Aerie CLI to support 1.4.0 pm_upload script.
Reference doc from [Aerie](https://nasa-ammos.github.io/aerie-docs/api/examples/simulation/#update-a-simulation-configuration)
and Parker PR on [graph_connect.py](https://github.jpl.nasa.gov/Europa-PESS/clipper-aerie/pull/1800/files#diff-82943426ed9b02ab3940e73464ffcbce2934b8423ef2653ce798c4803c756500) 
