### PR TITLE
Fix seq json query

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1610,6 +1610,4 @@ class AerieClient:
             id=command_dictionary_id,
             body=edsl_body
         )
-        if "seqJson" in resp:
-            return resp["seqJson"]
-        return resp
+        return resp["seqJson"]

--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1597,8 +1597,8 @@ class AerieClient:
         get_sequence_json_query = """
         query GenerateJSON($id: Int!, $body: String!) {
             getUserSequenceSeqJson(
-                command_dictionary_id: $id
-                edsl_body: $body
+                commandDictionaryID: $id
+                edslBody: $body
             ){
                 seqJson
             }

--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1610,4 +1610,6 @@ class AerieClient:
             id=command_dictionary_id,
             body=edsl_body
         )
-        return resp[0]
+        if "seqJson" in resp:
+            return resp["seqJson"]
+        return resp

--- a/tests/files/mock_responses/get_sequence_json.json
+++ b/tests/files/mock_responses/get_sequence_json.json
@@ -7,14 +7,12 @@
                 "id": 1
             }
         },
-        "response": [
-            {
-                "id": "2",
-                "metadata": {
-                    "testKey": "testValue"
-                },
-                "steps": []
-            }
-        ]
+        "response": {
+            "id": "2",
+            "metadata": {
+                "testKey": "testValue"
+            },
+            "steps": []
+        }
     }
 ]

--- a/tests/files/mock_responses/get_sequence_json.json
+++ b/tests/files/mock_responses/get_sequence_json.json
@@ -1,7 +1,7 @@
 [
     {
         "request": {
-            "query": "query GenerateJSON($id: Int!, $body: String!) { getUserSequenceSeqJson( command_dictionary_id: $id edsl_body: $body ){ seqJson } }",
+            "query": "query GenerateJSON($id: Int!, $body: String!) { getUserSequenceSeqJson( commandDictionaryID: $id edslBody: $body ){ seqJson } }",
             "variables": {
                 "body": "export default () => Sequence.new({ seqId: '2', metadata: {\"testKey\": \"testValue\"}, steps: [] });",
                 "id": 1

--- a/tests/files/mock_responses/get_sequence_json.json
+++ b/tests/files/mock_responses/get_sequence_json.json
@@ -7,12 +7,14 @@
                 "id": 1
             }
         },
-        "response": {
-            "id": "2",
-            "metadata": {
-                "testKey": "testValue"
-            },
-            "steps": []
+        "response":{
+            "seqJson": {
+                "id": "2",
+                "metadata": {
+                    "testKey": "testValue"
+                },
+                "steps": []
+            }
         }
     }
 ]


### PR DESCRIPTION
The GQL parameter names were off. Additionally, the response could change based on the type of session present. The mock host session used in unit tests overrides the `post_to_graphql` method, which may be why the response is different. The `get_sequence_json` query now accounts for this.