### PR TITLE
Add Hasura auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Help at script level:
 Usage: aerie-cli [OPTIONS] COMMAND [ARGS]...
 
 Options:
+  --hasura-admin-secret TEXT      [env var: HASURA_ADMIN_SECRET]
   --install-completion [bash|zsh|fish|powershell|pwsh]
                                   Install completion for the specified shell.
   --show-completion [bash|zsh|fish|powershell|pwsh]
@@ -277,9 +278,12 @@ Options:
   --help                          Show this message and exit.
 
 Commands:
-  plans
-  models
+  configurations
+  constraints
   expansion
+  models
+  plans
+  scheduling
 ```
 
 Help at command level:

--- a/README.md
+++ b/README.md
@@ -219,21 +219,13 @@ Each configuration must specify an authentication method, which depends on how t
 | `Native` | Default Aerie authentication scheme (Token-based)               |
 | `Cookie` | Cookie-based authentication (used on some advanced deployments) |
 
-A Hasura Admin Secret may be required for certain operations. Aerie-cli provides two ways of entering the secret.
+A Hasura Admin Secret may be required for certain operations.
 
-When the hasura admin secret is set by either method, it is not stored persistently. The secret is only used for the current command.
-
-1. Through the `--hasura-admin-secret` CLI option.
-
-    *Provide this option after ```aerie-cli```, but before any commands.*
-
-    *For example:*
-    ```
-    aerie-cli --hasura-admin-secret SECRET plans list
-    ```
-2. Through the `HASURA_GRAPHQL_ADMIN_SECRET` environment variable.
-
-    *This variable will be used by default. If both the `--hasura-admin-secret` CLI option and the enviornment variable are set, the program will utilize the CLI option's value.*
+The `--hasura-admin-secret` CLI option is used to set this secret. Provide this option after ```aerie-cli```, but before any commands. For example:
+```
+aerie-cli --hasura-admin-secret SECRET plans list
+```
+*The hasura admin secret is not stored persistently. The secret is only used for the current command.*
 ### Commands
 
 Begin by activating a configuration. This will store a persistent session with an Aerie host that will be used for all CLI commands.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ Each configuration must specify an authentication method, which depends on how t
 | `Native` | Default Aerie authentication scheme (Token-based)               |
 | `Cookie` | Cookie-based authentication (used on some advanced deployments) |
 
+A Hasura Admin Secret may be required for certain operations. Aerie-cli provides two ways of entering the secret.
+
+1. Through the `--hasura-admin-secret` CLI option.
+
+    *Provide this option after ```aerie-cli```, but before any commands.*
+
+    *For example:*
+    ```
+    aerie-cli --hasura-admin-secret SECRET plans list
+    ```
+2. Through the `HASURA_ADMIN_SECRET` environment variable.
+
+    *This variable will be used by default. If both the `--hasura-admin-secret` CLI option and the enviornment variable are set, the program will utilize the CLI option's value.*
 ### Commands
 
 Begin by activating a configuration. This will store a persistent session with an Aerie host that will be used for all CLI commands.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Each configuration must specify an authentication method, which depends on how t
 
 A Hasura Admin Secret may be required for certain operations. Aerie-cli provides two ways of entering the secret.
 
+When the hasura admin secret is set by either method, it is not stored persistently. The secret is only used for the current command.
+
 1. Through the `--hasura-admin-secret` CLI option.
 
     *Provide this option after ```aerie-cli```, but before any commands.*

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ A Hasura Admin Secret may be required for certain operations. Aerie-cli provides
     ```
     aerie-cli --hasura-admin-secret SECRET plans list
     ```
-2. Through the `HASURA_ADMIN_SECRET` environment variable.
+2. Through the `HASURA_GRAPHQL_ADMIN_SECRET` environment variable.
 
     *This variable will be used by default. If both the `--hasura-admin-secret` CLI option and the enviornment variable are set, the program will utilize the CLI option's value.*
 ### Commands
@@ -282,7 +282,7 @@ Help at script level:
 Usage: aerie-cli [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --hasura-admin-secret TEXT      [env var: HASURA_ADMIN_SECRET]
+  --hasura-admin-secret TEXT      [env var: HASURA_GRAPHQL_ADMIN_SECRET]
   --install-completion [bash|zsh|fish|powershell|pwsh]
                                   Install completion for the specified shell.
   --show-completion [bash|zsh|fish|powershell|pwsh]

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -22,7 +22,8 @@ app.add_typer(scheduling.app, name="scheduling")
 
 @app.callback()
 def setupGlobalCommandContext(
-        hasura_admin_secret = typer.Option(default="",envvar="HASURA_ADMIN_SECRET")
+        hasura_admin_secret = typer.Option(default="",envvar="HASURA_ADMIN_SECRET",
+                                           help="Hasura admin secret that will be put in the header of graphql requests")
     ):
     CommandContextManager.context = CommandContext(hasura_admin_secret=hasura_admin_secret)    
 

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -10,7 +10,7 @@ from aerie_cli.commands import expansion
 from aerie_cli.commands import constraints
 from aerie_cli.commands import scheduling
 from .persistent import NoActiveSessionError
-from aerie_cli.commands.command_context import CommandContext, CommandContextManager
+from aerie_cli.commands.command_context import CommandContext
 
 app = typer.Typer()
 app.add_typer(plans.app, name="plans")
@@ -25,7 +25,7 @@ def setupGlobalCommandContext(
         hasura_admin_secret = typer.Option(default="",
                                            help="Hasura admin secret that will be put in the header of graphql requests")
     ):
-    CommandContextManager.context = CommandContext(hasura_admin_secret=hasura_admin_secret)    
+    CommandContext.hasura_admin_secret = hasura_admin_secret
 
 def main():
     try:

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -22,7 +22,7 @@ app.add_typer(scheduling.app, name="scheduling")
 
 @app.callback()
 def setupGlobalCommandContext(
-        hasura_admin_secret = typer.Option(default="",envvar="HASURA_ADMIN_SECRET",
+        hasura_admin_secret = typer.Option(default="",envvar="HASURA_GRAPHQL_ADMIN_SECRET",
                                            help="Hasura admin secret that will be put in the header of graphql requests")
     ):
     CommandContextManager.context = CommandContext(hasura_admin_secret=hasura_admin_secret)    

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -22,7 +22,7 @@ app.add_typer(scheduling.app, name="scheduling")
 
 @app.callback()
 def setupGlobalCommandContext(
-        hasura_admin_secret = typer.Option(default="",envvar="HASURA_GRAPHQL_ADMIN_SECRET",
+        hasura_admin_secret = typer.Option(default="",
                                            help="Hasura admin secret that will be put in the header of graphql requests")
     ):
     CommandContextManager.context = CommandContext(hasura_admin_secret=hasura_admin_secret)    

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -9,8 +9,8 @@ from aerie_cli.commands import configurations
 from aerie_cli.commands import expansion
 from aerie_cli.commands import constraints
 from aerie_cli.commands import scheduling
-
 from .persistent import NoActiveSessionError
+from aerie_cli.commands.command_context import CommandContext, CommandContextManager
 
 app = typer.Typer()
 app.add_typer(plans.app, name="plans")
@@ -20,6 +20,11 @@ app.add_typer(expansion.app, name="expansion")
 app.add_typer(constraints.app, name="constraints")
 app.add_typer(scheduling.app, name="scheduling")
 
+@app.callback()
+def setupGlobalCommandContext(
+        hasura_admin_secret = typer.Option(default="",envvar="HASURA_ADMIN_SECRET")
+    ):
+    CommandContextManager.context = CommandContext(hasura_admin_secret=hasura_admin_secret)    
 
 def main():
     try:

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -1,0 +1,19 @@
+from aerie_cli.aerie_client import AerieClient
+import typer
+from types import SimpleNamespace
+
+app = typer.Typer()
+
+
+
+class CommandContext:
+    def __init__(self, hasura_admin_secret: str) -> None:
+        self._hasura_admin_secret = hasura_admin_secret
+    def get_hasura_admin_secret(self) -> str:
+        return self._hasura_admin_secret
+
+class CommandContextManager:
+    context: CommandContext = None
+    def __init__(self) -> None:
+        raise NotImplementedError
+        

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -2,16 +2,8 @@ import typer
 
 app = typer.Typer()
 
-
-
 class CommandContext:
-    def __init__(self, hasura_admin_secret: str) -> None:
-        self._hasura_admin_secret = hasura_admin_secret
-    def get_hasura_admin_secret(self) -> str:
-        return self._hasura_admin_secret
-
-class CommandContextManager:
-    context: CommandContext = None
+    hasura_admin_secret = None
     def __init__(self) -> None:
         raise NotImplementedError
         

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -1,6 +1,4 @@
-from aerie_cli.aerie_client import AerieClient
 import typer
-from types import SimpleNamespace
 
 app = typer.Typer()
 

--- a/src/aerie_cli/utils/sessions.py
+++ b/src/aerie_cli/utils/sessions.py
@@ -3,7 +3,7 @@ import requests
 from aerie_cli.aerie_host import AerieHostSession
 from aerie_cli.aerie_client import AerieClient
 from aerie_cli.persistent import PersistentSessionManager
-from aerie_cli.commands.command_context import CommandContextManager
+from aerie_cli.commands.command_context import CommandContext
 
 def get_active_session_client():
     """Instantiate AerieClient with the active host session
@@ -15,7 +15,7 @@ def get_active_session_client():
         AerieClient
     """
     session = PersistentSessionManager.get_active_session()
-    hasura_secret = CommandContextManager.context.get_hasura_admin_secret()
+    hasura_secret = CommandContext.hasura_admin_secret
     if hasura_secret:
         session.session.headers["x-hasura-admin-secret"] = hasura_secret
     return AerieClient(session)

--- a/src/aerie_cli/utils/sessions.py
+++ b/src/aerie_cli/utils/sessions.py
@@ -3,7 +3,7 @@ import requests
 from aerie_cli.aerie_host import AerieHostSession
 from aerie_cli.aerie_client import AerieClient
 from aerie_cli.persistent import PersistentSessionManager
-
+from aerie_cli.commands.command_context import CommandContextManager
 
 def get_active_session_client():
     """Instantiate AerieClient with the active host session
@@ -15,6 +15,9 @@ def get_active_session_client():
         AerieClient
     """
     session = PersistentSessionManager.get_active_session()
+    hasura_secret = CommandContextManager.context.get_hasura_admin_secret()
+    if hasura_secret:
+        session.session.headers["x-hasura-admin-secret"] = hasura_secret
     return AerieClient(session)
 
 


### PR DESCRIPTION
- Added a global command line option, ```--hasura-admin-secret```, to resolve #36 
- Added Hasura authorization by adding a hasura admin secret to the header of graphql requests, which closes #22 