### PR TITLE
CLI Argument Updates

### DIFF
--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -57,7 +57,7 @@ def create_configuration(
 @app.command('update')
 def update_configuration(
     name: str = typer.Option(
-        None, help='Name of the configuration to update', metavar='NAME'
+        None, '--name', '-n', help='Name of the configuration to update', metavar='NAME'
     )
 ):
     """
@@ -139,7 +139,7 @@ def upload_configurations(
 @app.command('activate')
 def activate_session(
     name: str = typer.Option(
-        None, help='Name for this configuration', metavar='NAME')
+        None, '--name', '-n', help='Name for this configuration', metavar='NAME')
 ):
     """
     Activate a session with an Aerie host using a given configuration
@@ -219,7 +219,7 @@ def list_configurations():
 @app.command('delete')
 def delete_configuration(
     name: str = typer.Option(
-        "", help='Name for this configuration', metavar='NAME', show_default=False)
+        None, '--name', '-n', help='Name for this configuration', metavar='NAME', show_default=False)
 ):
     """
     Delete an Aerie host configuration

--- a/src/aerie_cli/commands/metadata.py
+++ b/src/aerie_cli/commands/metadata.py
@@ -13,11 +13,15 @@ app = typer.Typer()
 @app.command()
 def upload(
     schema_path: str = typer.Option(
-        ..., help="path to JSON file defining the schema to be created", prompt=True
+        ...,
+        "--schema-path",
+        "-i",
+        help="path to JSON file defining the schema to be created",
+        prompt=True,
     ),
 ):
     """Add to the metadata schema from a .json file.
-    
+
     JSON file contents should include a list schemas, each containing a key for its name and value for its type.
     """
     client = get_active_session_client()
@@ -32,7 +36,7 @@ def upload(
 @app.command()
 def delete(
     schema_name: str = typer.Option(
-        ..., help="Name of schema to be deleted", prompt=True
+        ..., "--schema-name", "-n", help="Name of schema to be deleted", prompt=True
     ),
 ):
     """Delete a metadata schema by its name."""
@@ -57,6 +61,7 @@ def list():
 
     console = Console()
     console.print(table)
+
 
 @app.command()
 def clean():

--- a/src/aerie_cli/commands/models.py
+++ b/src/aerie_cli/commands/models.py
@@ -71,7 +71,7 @@ def upload(
 @app.command()
 def delete(
     model_id: int = typer.Option(
-        ..., help="Mission model ID to be deleted", prompt=True
+        ..., "--model-id", "-m", help="Mission model ID to be deleted", prompt=True
     ),
 ):
     """Delete a mission model by its model id."""

--- a/src/aerie_cli/commands/models.py
+++ b/src/aerie_cli/commands/models.py
@@ -13,26 +13,28 @@ app = typer.Typer()
 @app.command()
 def upload(
     mission_model_path: str = typer.Option(
-        ..., help="The input file from which to create an Aerie model", prompt=True
+        ...,
+        "--mission-model-path",
+        "-i",
+        help="The input file from which to create an Aerie model",
+        prompt=True,
     ),
-    model_name: str = typer.Option(..., help="Name of mission model", prompt=True),
-    mission: str = typer.Option(
-        ..., help="Mission to associate with the model", prompt=True
-    ),
-    time_tag_version: bool = typer.Option(
-        False, "--time-tag-version", help="Use timestamp for model version"
+    model_name: str = typer.Option(
+        ..., "--model-name", "-n", help="Name of mission model", prompt=True
     ),
     version: str = typer.Option(
         "",
+        "--version",
+        "-v",
         help="Mission model verison",
         show_default=True,
         prompt=True,
     ),
+    time_tag_version: bool = typer.Option(
+        False, "--time-tag-version", help="Use timestamp for model version"
+    ),
     sim_template: str = typer.Option(
-        "",
-        help="Simulation template file",
-        show_default=True,
-        prompt=True,
+        "", help="Simulation template file", show_default=True
     ),
 ):
     """Upload a single mission model from a .jar file."""
@@ -47,7 +49,7 @@ def upload(
     model_id = client.upload_mission_model(
         mission_model_path=mission_model_path,
         project_name=model_name,
-        mission=mission,
+        mission="",
         version=version,
     )
 
@@ -61,11 +63,9 @@ def upload(
 
         # Attach sim template to model
         client.upload_sim_template(model_id=model_id, args=json_obj, name=name)
-        print(f"Attached simulation template to model {model_id}.")
+        typer.echo(f"Attached simulation template to model {model_id}.")
 
-    typer.echo(
-        f"Created new mission model: {model_name} with Model ID: {model_id}"
-    )
+    typer.echo(f"Created new mission model: {model_name} with Model ID: {model_id}")
 
 
 @app.command()

--- a/src/aerie_cli/commands/plans.py
+++ b/src/aerie_cli/commands/plans.py
@@ -33,9 +33,9 @@ def download(
 def download_simulation(
     sim_id: int = typer.Option(
         ..., '--sim-id', '-s',
-        help="Simulation ID", prompt=True),
+        help="Simulation Dataset ID", prompt=True),
     output: str = typer.Option(
-        ..., '--output', '-s',
+        ..., '--output', '-o',
         help="The output file destination", prompt=True)
 ):
     """

--- a/src/aerie_cli/commands/plans.py
+++ b/src/aerie_cli/commands/plans.py
@@ -15,12 +15,12 @@ app = typer.Typer()
 
 @app.command()
 def download(
-    id: int = typer.Option(..., help="Plan ID", prompt=True),
+    id: int = typer.Option(..., "--plan-id", "--id", "-p", help="Plan ID", prompt=True),
     full_args: str = typer.Option(
         "",
         help="true, false, or comma separated list of activity types for which to get full arguments.  Otherwise only modified arguments are returned.  Defaults to false.",
     ),
-    output: str = typer.Option(..., help="The output file destination", prompt=True)
+    output: str = typer.Option(..., "--output", "-o", help="The output file destination", prompt=True)
 ):
     """Download a plan and save it locally as a JSON file."""
     plan = get_active_session_client().get_activity_plan_by_id(id, full_args)
@@ -54,7 +54,7 @@ def download_resources(
         ..., '--sim-id', '-s',
         help="Simulation Dataset ID", prompt='Simulation Dataset ID'),
     csv: bool = typer.Option(
-        False, "--csv/--json", help="Download as CSV"
+        False, "--csv/--json", help="Specify file format. Defaults to JSON"
     ),
     output: str = typer.Option(
         ..., '--output', '-o',
@@ -160,10 +160,10 @@ def download_resources(
 @app.command()
 def upload(
     input: str = typer.Option(
-        ..., help="The input file from which to create an Aerie plan", prompt=True
+        ..., "--input", "-i", help="The input file from which to create an Aerie plan", prompt=True
     ),
     model_id: int = typer.Option(
-        ..., help="The mission model ID to associate with the plan", prompt=True
+        ..., "--model-id", "-m", help="The mission model ID to associate with the plan", prompt=True
     ),
     time_tag: bool = typer.Option(False, help="Append time tag to plan name"),
 ):
@@ -181,9 +181,9 @@ def upload(
 
 @app.command()
 def duplicate(
-    id: int = typer.Option(..., help="Plan ID", prompt=True),
+    id: int = typer.Option(..., "--plan-id", "--id", "-p", help="Plan ID", prompt=True),
     duplicated_plan_name: str = typer.Option(
-        ..., help="The name for the duplicated plan", prompt=True
+        ..., "--duplicate-plan-name", "-n", help="The name for the duplicated plan", prompt=True
     )
 ):
     """Duplicate an existing plan."""
@@ -193,16 +193,14 @@ def duplicate(
     plan_to_duplicate = ActivityPlanCreate.from_plan_read(plan)
     plan_to_duplicate.name = duplicated_plan_name
     duplicated_plan_id = client.create_activity_plan(plan.model_id, plan_to_duplicate)
-    typer.echo(
-        f"Duplicated activity plan at: {client.ui_path()}/plans/{duplicated_plan_id}"
-    )
+    typer.echo(f"Duplicate activity plan created with ID: {duplicated_plan_id}")
 
 
 @app.command()
 def simulate(
     id: int = typer.Option(..., help="Plan ID", prompt=True),
     output: Union[str, None] = typer.Option(
-        None, help="The output file destination for simulation results (if desired)"
+        None, "--output", "-o", help="The output file destination for simulation results (if desired)"
     ),
     poll_period: int = typer.Option(
         5,
@@ -298,7 +296,7 @@ def update_config(
 
 @app.command()
 def delete(
-    plan_id: int = typer.Option(..., help="Plan ID to be deleted", prompt=True),
+    plan_id: int = typer.Option(..., "--plan-id", "-p", help="Plan ID to be deleted", prompt=True),
 ):
     """Delete an activity plan by its id."""
 


### PR DESCRIPTION
Closes #7 

General quality-of-life updates to CLI arguments:

- Fixes a couple of mistakes/unclear options
- Adds abbreviated options to common args: `-i` for input files, `-p`/`--plan-id` for plan IDs, `-o` for output files, `-n` for names
- Makes the `models upload` command much easier to use. This shouldn't break any existing scripts, but it does:
  - make the `sim_template` argument optional (previously, you needed to explicitly pass an empty string)
  - set the mission name to an empty string (same thing the UI does currently)
  - add abbreviated options for the Jar path, model name, and version