### PR TITLE
Refactor command context

### DIFF
--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -12,6 +12,6 @@ class CommandContext:
     @classmethod
     def get_client(cls) -> AerieClient:
         client = get_active_session_client()
-        if CommandContext.hasura_admin_secret:
-            client.host_session.session.headers["x-hasura-admin-secret"] = CommandContext.hasura_admin_secret
+        if cls.hasura_admin_secret:
+            client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret
         return client

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -1,4 +1,6 @@
 import typer
+from aerie_cli.aerie_client import AerieClient
+from aerie_cli.utils.sessions import get_active_session_client
 
 app = typer.Typer()
 
@@ -6,4 +8,10 @@ class CommandContext:
     hasura_admin_secret = None
     def __init__(self) -> None:
         raise NotImplementedError
-        
+
+    @classmethod
+    def get_client(cls) -> AerieClient:
+        client = get_active_session_client()
+        if CommandContext.hasura_admin_secret:
+            client.host_session.session.headers["x-hasura-admin-secret"] = CommandContext.hasura_admin_secret
+        return client

--- a/src/aerie_cli/commands/constraints.py
+++ b/src/aerie_cli/commands/constraints.py
@@ -5,7 +5,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.commands.command_context import CommandContext
 
 app = typer.Typer()
 
@@ -23,7 +23,7 @@ def upload(
     if model_id is None and plan_id is None:
         model_id = typer.prompt("Model id")
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     with open(constraint_file) as in_file:
         contents = in_file.readlines()
         str_contents = " ".join(contents)
@@ -44,7 +44,7 @@ def delete(
 ):
     """Delete a constraint"""
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     client.delete_constraint(id)
     typer.echo(f"Successfully deleted constraint {id}")
 
@@ -55,7 +55,7 @@ def update(
 ):
     """Update a constraint"""
     
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     constraint = client.get_constraint_by_id(id)
     with open(constraint_file) as in_file:
         contents = in_file.readlines()
@@ -76,7 +76,7 @@ def violations(
     plan_id: int = typer.Option(..., help="The plan id for the violation", prompt=True)
 ):
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     constraint_violations = client.get_constraint_violations(plan_id)
     typer.echo(f"Constraint violations: {constraint_violations}")
     

--- a/src/aerie_cli/commands/expansion.py
+++ b/src/aerie_cli/commands/expansion.py
@@ -7,7 +7,7 @@ import fnmatch
 from rich.console import Console
 from rich.table import Table
 
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.commands.command_context import CommandContext
 from aerie_cli.utils.prompts import select_from_list
 from aerie_cli.schemas.client import ExpansionRun
 
@@ -36,7 +36,7 @@ def expand_simulation(
     """
     Run command expansion on a simulation dataset
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     expansion_run_id = client.expand_simulation(
         int(simulation_dataset_id), int(expansion_set_id))
@@ -69,7 +69,7 @@ def list_expansion_runs(
         elif choice == 'Simulation Dataset ID':
             simulation_dataset_id = typer.prompt('Enter Simulation Dataset ID')
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     if simulation_dataset_id is None:
         simulation_datasets = client.get_simulation_dataset_ids_by_plan_id(
@@ -129,7 +129,7 @@ def list_sequences(
         elif choice == 'Simulation Dataset ID':
             simulation_dataset_id = typer.prompt('Enter Simulation Dataset ID')
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     if simulation_dataset_id is None:
         simulation_datasets = client.get_simulation_dataset_ids_by_plan_id(
@@ -173,7 +173,7 @@ def create_sequence(
     """
     Create a sequence on a simulation dataset
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     existing_sequences = client.list_sequences(simulation_dataset_id)
     if seq_id in existing_sequences:
         Console().print(f"Sequence already exists: {seq_id}", style='red')
@@ -230,7 +230,7 @@ def delete_sequence(
     """
     Delete sequence on a simulation dataset
     """
-    get_active_session_client().delete_sequence(
+    CommandContext.get_client().delete_sequence(
         seq_id, simulation_dataset_id)
 
     Console().print(f"Successfully deleted sequence: {seq_id}", style='green')
@@ -258,7 +258,7 @@ def download_sequence(
         output_fn == '.json'
     output_fn = Path(output_fn)
 
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     seq_dict = client.get_expanded_sequence(seq_id, int(simulation_dataset_id))
 
@@ -273,7 +273,7 @@ def list_expansion_sets():
     """
     List all expansion sets
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     sets = client.list_expansion_sets()
     cmd_dicts = client.list_command_dictionaries()
     cmd_dicts = {c.id: c for c in cmd_dicts}
@@ -308,7 +308,7 @@ def get_expansion_set(
     """
     View all rules in an expansion set
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     sets = client.list_expansion_sets()
     try:
         set = next(filter(lambda s: s.id == int(expansion_set_id), sets))
@@ -353,7 +353,7 @@ def create_expansion_set(
     Filters to only use rules designated for the given mission model and 
     command dictionary.
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
     expansion_rules = client.get_rules_by_type()
 
     if not activity_types:

--- a/src/aerie_cli/commands/metadata.py
+++ b/src/aerie_cli/commands/metadata.py
@@ -5,7 +5,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.commands.command_context import CommandContext
 
 app = typer.Typer()
 
@@ -24,7 +24,7 @@ def upload(
 
     JSON file contents should include a list schemas, each containing a key for its name and value for its type.
     """
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     with open(schema_path) as in_file:
         contents = in_file.read()
@@ -40,7 +40,7 @@ def delete(
     ),
 ):
     """Delete a metadata schema by its name."""
-    resp = get_active_session_client().delete_directive_metadata_schema(schema_name)
+    resp = CommandContext.get_client().delete_directive_metadata_schema(schema_name)
     typer.echo(f"Schema `{resp}` has been removed.")
 
 
@@ -48,7 +48,7 @@ def delete(
 def list():
     """List uploaded metadata schemas."""
 
-    resp = get_active_session_client().get_directive_metadata()
+    resp = CommandContext.get_client().get_directive_metadata()
 
     table = Table(title="Metadata Schemas")
     table.add_column("Key", style="magenta")
@@ -66,7 +66,7 @@ def list():
 @app.command()
 def clean():
     """Delete all metadata schemas."""
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     resp = client.get_directive_metadata()
     for schema in resp:

--- a/src/aerie_cli/commands/models.py
+++ b/src/aerie_cli/commands/models.py
@@ -5,7 +5,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.commands.command_context import CommandContext
 
 app = typer.Typer()
 
@@ -43,7 +43,7 @@ def upload(
         version = arrow.utcnow().isoformat()
 
     # Initialize Aerie client
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     # Upload mission model file to Aerie server
     model_id = client.upload_mission_model(
@@ -76,14 +76,14 @@ def delete(
 ):
     """Delete a mission model by its model id."""
 
-    model_name = get_active_session_client().delete_mission_model(model_id)
+    model_name = CommandContext.get_client().delete_mission_model(model_id)
     typer.echo(f"Mission Model `{model_name}` with ID: {model_id} has been removed.")
 
 
 @app.command()
 def clean():
     """Delete all mission models."""
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     resp = client.get_mission_models()
     for api_mission_model in resp:
@@ -96,7 +96,7 @@ def clean():
 def list():
     """List uploaded mission models."""
 
-    resp = get_active_session_client().get_mission_models()
+    resp = CommandContext.get_client().get_mission_models()
 
     # Create output table
     table = Table(title="Current Mission Models")

--- a/src/aerie_cli/commands/scheduling.py
+++ b/src/aerie_cli/commands/scheduling.py
@@ -1,6 +1,6 @@
 import typer
 
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.commands.command_context import CommandContext
 
 app = typer.Typer()
 
@@ -19,7 +19,7 @@ def upload(
     )
 ): 
     """Upload scheduling goal"""
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     with open(schedule) as in_file:
         i = 0
@@ -43,7 +43,7 @@ def delete(
     )
 ):
     """Delete scheduling goal"""
-    client = get_active_session_client()
+    client = CommandContext.get_client()
 
     resp = client.delete_scheduling_goal(goal_id)
     typer.echo("Successfully deleted Goal ID: " + str(resp))

--- a/src/aerie_cli/utils/sessions.py
+++ b/src/aerie_cli/utils/sessions.py
@@ -3,7 +3,6 @@ import requests
 from aerie_cli.aerie_host import AerieHostSession
 from aerie_cli.aerie_client import AerieClient
 from aerie_cli.persistent import PersistentSessionManager
-from aerie_cli.commands.command_context import CommandContext
 
 def get_active_session_client():
     """Instantiate AerieClient with the active host session
@@ -15,9 +14,6 @@ def get_active_session_client():
         AerieClient
     """
     session = PersistentSessionManager.get_active_session()
-    hasura_secret = CommandContext.hasura_admin_secret
-    if hasura_secret:
-        session.session.headers["x-hasura-admin-secret"] = hasura_secret
     return AerieClient(session)
 
 


### PR DESCRIPTION
Closes #47.

- `CommandContext.get_client()` now abstracts util's `get_active_session_client()` in all command functions.
- The hasura admin secret is now injected in `CommandContext.get_client()` rather than util's `get_active_session_client()`.