### PR TITLE
Add configuration CLI option

### DIFF
--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -15,6 +15,7 @@ from aerie_cli.commands import metadata
 from .persistent import NoActiveSessionError
 from aerie_cli.commands.command_context import CommandContext
 from aerie_cli.__version__ import __version__
+from aerie_cli.utils.configurations import find_configuration
 
 app = typer.Typer()
 app.add_typer(plans.app, name="plans")
@@ -31,6 +32,15 @@ def print_version(print_version: bool):
         typer.echo(__version__)
         raise typer.Exit()
 
+def set_configuration(configuration: str):
+    if configuration == None:
+        return
+
+    found_configuration = find_configuration(configuration)
+    if found_configuration == None:
+        raise RuntimeError(f"No configuration exists with the path or name {configuration}")
+
+    CommandContext.configuration = found_configuration
 
 @app.callback()
 def app_callback(
@@ -44,6 +54,15 @@ def app_callback(
     hasura_admin_secret=typer.Option(
         default="",
         help="Hasura admin secret that will be put in the header of graphql requests.",
+    ),
+    configuration=typer.Option(
+        None,
+        "--configuration",
+        "-c",
+        callback=set_configuration,
+        help="Set a configuration to use rather than the persistent configuration.\n\
+            Accepts either a configuration name or the path to a configuration json.\n\
+            Configuration names are prioritized over paths.",
     ),
 ):
     setup_global_command_context(hasura_admin_secret)

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -35,12 +35,7 @@ def print_version(print_version: bool):
 def set_alternate_configuration(configuration_identifier: str):
     if configuration_identifier == None:
         return
-    try:
-        found_configuration = find_configuration(configuration_identifier)
-    except ValueError as e:
-        raise ValueError("File provided could not be converted to json")
-    except FileNotFoundError as e:
-        raise ValueError(f"No configuration exists with the path or name {configuration_identifier}")
+    found_configuration = find_configuration(configuration_identifier)
 
     CommandContext.alternate_configuration = found_configuration
 

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -35,10 +35,12 @@ def print_version(print_version: bool):
 def set_configuration(configuration: str):
     if configuration == None:
         return
-
-    found_configuration = find_configuration(configuration)
-    if found_configuration == None:
-        raise RuntimeError(f"No configuration exists with the path or name {configuration}")
+    try:
+        found_configuration = find_configuration(configuration)
+    except ValueError as e:
+        raise ValueError("File provided could not be converted to json")
+    except FileNotFoundError as e:
+        raise ValueError(f"No configuration exists with the path or name {configuration}")
 
     CommandContext.configuration = found_configuration
 

--- a/src/aerie_cli/__main__.py
+++ b/src/aerie_cli/__main__.py
@@ -32,17 +32,17 @@ def print_version(print_version: bool):
         typer.echo(__version__)
         raise typer.Exit()
 
-def set_configuration(configuration: str):
-    if configuration == None:
+def set_alternate_configuration(configuration_identifier: str):
+    if configuration_identifier == None:
         return
     try:
-        found_configuration = find_configuration(configuration)
+        found_configuration = find_configuration(configuration_identifier)
     except ValueError as e:
         raise ValueError("File provided could not be converted to json")
     except FileNotFoundError as e:
-        raise ValueError(f"No configuration exists with the path or name {configuration}")
+        raise ValueError(f"No configuration exists with the path or name {configuration_identifier}")
 
-    CommandContext.configuration = found_configuration
+    CommandContext.alternate_configuration = found_configuration
 
 @app.callback()
 def app_callback(
@@ -61,7 +61,7 @@ def app_callback(
         None,
         "--configuration",
         "-c",
-        callback=set_configuration,
+        callback=set_alternate_configuration,
         help="Set a configuration to use rather than the persistent configuration.\n\
             Accepts either a configuration name or the path to a configuration json.\n\
             Configuration names are prioritized over paths.",

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -1,6 +1,6 @@
 import typer
 from aerie_cli.aerie_client import AerieClient
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.utils.sessions import get_active_session_client, start_session_from_configuration
 from aerie_cli.aerie_host import AerieHostConfiguration
 
 app = typer.Typer()
@@ -23,7 +23,7 @@ class CommandContext:
         # then the returned client will be derived from that configuration.
         client = None
         if cls.alternate_configuration != None and client == None:
-            session = cls.alternate_configuration.start_session()
+            session = start_session_from_configuration(cls.alternate_configuration)
             client = AerieClient(session)
 
         if client == None:

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -7,7 +7,7 @@ app = typer.Typer()
 
 class CommandContext:
     hasura_admin_secret: str = None
-    configuration: AerieHostConfiguration = None
+    alternate_configuration: AerieHostConfiguration = None
     __client: AerieClient = None
 
     def __init__(self) -> None:
@@ -22,14 +22,13 @@ class CommandContext:
         """
         # If the configuration was set in the CLI by the user,
         # then the returned client will be derived from that configuration.
-        if cls.configuration != None and cls.__client == None:
-            session = cls.configuration.start_session()
+        if cls.alternate_configuration != None and cls.__client == None:
+            session = cls.alternate_configuration.start_session()
             cls.__client = AerieClient(session)
 
         if cls.__client == None:
             # no configuration specified in CLI, so the active session will be used instead
             cls.__client = get_active_session_client()
-            cls.configuration = cls.__client.host_session.configuration_name
 
         if cls.hasura_admin_secret:
             cls.__client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -1,17 +1,37 @@
 import typer
 from aerie_cli.aerie_client import AerieClient
 from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.aerie_host import AerieHostConfiguration
 
 app = typer.Typer()
 
 class CommandContext:
-    hasura_admin_secret = None
+    hasura_admin_secret: str = None
+    configuration: AerieHostConfiguration = None
+    __client: AerieClient = None
+
     def __init__(self) -> None:
         raise NotImplementedError
 
     @classmethod
     def get_client(cls) -> AerieClient:
-        client = get_active_session_client()
+        """Get the AerieClient for any command's execution.
+        
+        Returns:
+            AerieClient
+        """
+        # If the configuration was set in the CLI by the user,
+        # then the returned client will be derived from that configuration.
+        if cls.configuration != None and cls.__client == None:
+            session = cls.configuration.start_session()
+            cls.__client = AerieClient(session)
+
+        if cls.__client == None:
+            # no configuration specified in CLI, so the active session will be used instead
+            cls.__client = get_active_session_client()
+            cls.configuration = cls.__client.host_session.configuration_name
+
         if cls.hasura_admin_secret:
-            client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret
-        return client
+            cls.__client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret
+
+        return cls.__client

--- a/src/aerie_cli/commands/command_context.py
+++ b/src/aerie_cli/commands/command_context.py
@@ -8,7 +8,6 @@ app = typer.Typer()
 class CommandContext:
     hasura_admin_secret: str = None
     alternate_configuration: AerieHostConfiguration = None
-    __client: AerieClient = None
 
     def __init__(self) -> None:
         raise NotImplementedError
@@ -22,15 +21,16 @@ class CommandContext:
         """
         # If the configuration was set in the CLI by the user,
         # then the returned client will be derived from that configuration.
-        if cls.alternate_configuration != None and cls.__client == None:
+        client = None
+        if cls.alternate_configuration != None and client == None:
             session = cls.alternate_configuration.start_session()
-            cls.__client = AerieClient(session)
+            client = AerieClient(session)
 
-        if cls.__client == None:
+        if client == None:
             # no configuration specified in CLI, so the active session will be used instead
-            cls.__client = get_active_session_client()
+            client = get_active_session_client()
 
         if cls.hasura_admin_secret:
-            cls.__client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret
+            client.host_session.session.headers["x-hasura-admin-secret"] = cls.hasura_admin_secret
 
-        return cls.__client
+        return client

--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from aerie_cli.aerie_host import AuthMethod, AerieHostConfiguration
 from aerie_cli.persistent import PersistentConfigurationManager, PersistentSessionManager, delete_all_persistent_files, NoActiveSessionError, CONFIGURATION_FILE_PATH
 from aerie_cli.utils.prompts import select_from_list
-
+from aerie_cli.utils.sessions import start_session_from_configuration
 
 app = typer.Typer()
 
@@ -150,17 +150,7 @@ def activate_session(
 
     conf = PersistentConfigurationManager.get_configuration_by_name(name)
 
-    if conf.auth_method != AuthMethod.NONE:
-        if conf.username is None:
-            username = typer.prompt('Username')
-        else:
-            username = conf.username
-        password = typer.prompt('Password', hide_input=True)
-    else:
-        username = None
-        password = None
-
-    session = conf.start_session(username, password)
+    session = start_session_from_configuration(conf)
     PersistentSessionManager.set_active_session(session)
 
 

--- a/src/aerie_cli/utils/configurations.py
+++ b/src/aerie_cli/utils/configurations.py
@@ -8,6 +8,10 @@ def find_configuration(configuration: str) -> AerieHostConfiguration:
     
     configuration (str): The name or path of a configuration. Paths should be to a configuration json file.
 
+    Raises:
+        ValueError
+        FileNotFoundError
+
     Returns:
         AerieHostConfiguration
     """
@@ -16,14 +20,9 @@ def find_configuration(configuration: str) -> AerieHostConfiguration:
         if persistent_configuration.name != configuration:
             continue
         return persistent_configuration
+
     # search for configuration by path
-    try:
-        with open(configuration, 'r') as fid:
-            try:
-                found_configuration = json.load(fid)
-            except ValueError as e:
-                return None
-    except FileNotFoundError as e:
-        return None
+    with open(configuration, 'r') as fid:
+        found_configuration = json.load(fid)
     
     return AerieHostConfiguration.from_dict(found_configuration)

--- a/src/aerie_cli/utils/configurations.py
+++ b/src/aerie_cli/utils/configurations.py
@@ -3,10 +3,10 @@ from aerie_cli.persistent import PersistentConfigurationManager
 
 import json
 
-def find_configuration(configuration: str) -> AerieHostConfiguration:
+def find_configuration(configuration_identifier: str) -> AerieHostConfiguration:
     """Find a configuration by name or path.
     
-    configuration (str): The name or path of a configuration. Paths should be to a configuration json file.
+    configuration_identifier (str): The name or path of a configuration. Paths should be to a configuration json file.
 
     Raises:
         ValueError
@@ -17,12 +17,12 @@ def find_configuration(configuration: str) -> AerieHostConfiguration:
     """
     # search for configuration by name
     for persistent_configuration in PersistentConfigurationManager.get_configurations():
-        if persistent_configuration.name != configuration:
+        if persistent_configuration.name != configuration_identifier:
             continue
         return persistent_configuration
 
     # search for configuration by path
-    with open(configuration, 'r') as fid:
+    with open(configuration_identifier, 'r') as fid:
         found_configuration = json.load(fid)
     
     return AerieHostConfiguration.from_dict(found_configuration)

--- a/src/aerie_cli/utils/configurations.py
+++ b/src/aerie_cli/utils/configurations.py
@@ -1,0 +1,29 @@
+from aerie_cli.aerie_host import AerieHostConfiguration
+from aerie_cli.persistent import PersistentConfigurationManager
+
+import json
+
+def find_configuration(configuration: str) -> AerieHostConfiguration:
+    """Find a configuration by name or path.
+    
+    configuration (str): The name or path of a configuration. Paths should be to a configuration json file.
+
+    Returns:
+        AerieHostConfiguration
+    """
+    # search for configuration by name
+    for persistent_configuration in PersistentConfigurationManager.get_configurations():
+        if persistent_configuration.name != configuration:
+            continue
+        return persistent_configuration
+    # search for configuration by path
+    try:
+        with open(configuration, 'r') as fid:
+            try:
+                found_configuration = json.load(fid)
+            except ValueError as e:
+                return None
+    except FileNotFoundError as e:
+        return None
+    
+    return AerieHostConfiguration.from_dict(found_configuration)

--- a/src/aerie_cli/utils/configurations.py
+++ b/src/aerie_cli/utils/configurations.py
@@ -22,7 +22,13 @@ def find_configuration(configuration_identifier: str) -> AerieHostConfiguration:
         return persistent_configuration
 
     # search for configuration by path
-    with open(configuration_identifier, 'r') as fid:
-        found_configuration = json.load(fid)
+    try:
+        with open(configuration_identifier, 'r') as fid:
+            try:
+                found_configuration = json.load(fid)
+            except ValueError as e:
+                raise ValueError("File provided could not be converted to json")
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"No configuration exists with the path or name {configuration_identifier}")
     
     return AerieHostConfiguration.from_dict(found_configuration)

--- a/src/aerie_cli/utils/sessions.py
+++ b/src/aerie_cli/utils/sessions.py
@@ -1,6 +1,7 @@
 import requests
+import typer
 
-from aerie_cli.aerie_host import AerieHostSession
+from aerie_cli.aerie_host import AerieHostSession, AerieHostConfiguration, AuthMethod
 from aerie_cli.aerie_client import AerieClient
 from aerie_cli.persistent import PersistentSessionManager
 
@@ -70,3 +71,16 @@ def get_preauthenticated_client_cookie(cookie_name: str, cookie_value: str, grap
     if not aerie_session.ping_gateway():
         raise RuntimeError(f"Failed to connect to host")
     return AerieClient(aerie_session)
+
+def start_session_from_configuration(configuration: AerieHostConfiguration):
+    if configuration.auth_method != AuthMethod.NONE:
+        if configuration.username is None:
+            username = typer.prompt('Username')
+        else:
+            username = configuration.username
+        password = typer.prompt('Password', hide_input=True)
+    else:
+        username = None
+        password = None
+
+    return configuration.start_session(username, password)


### PR DESCRIPTION
- Added a --configurations/-c CLI option
- Added a find_configurations helper to find a configuration by name or path
- Added a configuration to CommandContext
- If the configurations CLI option is used, a new session is initialized the first time CommandContext.get_client is called

closes #14 