### PR TITLE
Update gateway ping to check /auth/session

### DIFF
--- a/src/aerie_cli/aerie_host.py
+++ b/src/aerie_cli/aerie_host.py
@@ -154,15 +154,13 @@ class AerieHostSession:
         else:
             raise RuntimeError(f"Error uploading file: {file_name}")
 
-    def ping_gateway(self) -> bool:
-
+    def check_auth(self) -> bool:
         try:
-            resp = self.session.get(self.gateway_url + "/health")
+            resp = self.session.get(self.gateway_url + "/auth/session")
         except requests.exceptions.ConnectionError:
             return False
         try:
-            if "uptimeMinutes" in resp.json().keys():
-                return True
+            return resp.json()["success"]
         except Exception:
             return False
 
@@ -225,7 +223,7 @@ class AerieHostSession:
 
         aerie_session = cls(session, graphql_url, gateway_url, configuration_name)
 
-        if not aerie_session.ping_gateway():
+        if not aerie_session.check_auth():
             raise RuntimeError(f"Failed to open session")
 
         return aerie_session

--- a/src/aerie_cli/aerie_host.py
+++ b/src/aerie_cli/aerie_host.py
@@ -155,6 +155,11 @@ class AerieHostSession:
             raise RuntimeError(f"Error uploading file: {file_name}")
 
     def check_auth(self) -> bool:
+        """Checks if authentication was successful. Looks for errors received after pinging GATEWAY_URL/auth/session.
+        
+        Returns:
+            bool: True if there were no errors in a ping against GATEWAY_URL/auth/session, False otherwise
+        """
         try:
             resp = self.session.get(self.gateway_url + "/auth/session")
         except requests.exceptions.ConnectionError:

--- a/src/aerie_cli/persistent.py
+++ b/src/aerie_cli/persistent.py
@@ -160,7 +160,7 @@ class PersistentSessionManager:
     @classmethod
     def set_active_session(cls, session: AerieHostSession) -> bool:
 
-        if not session.ping_gateway():
+        if not session.check_auth():
             return False
 
         fs: List[Path] = [

--- a/tests/unit_tests/test_persistent_session.py
+++ b/tests/unit_tests/test_persistent_session.py
@@ -20,12 +20,8 @@ class MockAerieHostSession(AerieHostSession):
         self.graphql_url = "Test"
         self.gateway_url = "Test"
 
-    def ping_gateway(self) -> bool:
+    def check_auth(self) -> bool:
         return self.ping_success
-
-
-TEST_TIME = datetime.datetime(2025, 1, 1, 0, 0, 0)
-
 
 @pytest.fixture
 def persistent_path(tmp_path: Path):


### PR DESCRIPTION
- We now use `/auth/session/` in place of `/health` for checking authentication
- Breaking Change: Renamed `ping_gateway` to `check_auth`

Closes #30 