### PR TITLE
Update configurations after clean

### DIFF
--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -243,4 +243,5 @@ def delete_all_files(
 
     delete_all_persistent_files()
     # Update the PersistentConfigurationManager's cached configurations to account for the clean
+    PersistentSessionManager.unset_active_session()
     PersistentConfigurationManager.read_configurations()

--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -242,3 +242,5 @@ def delete_all_files(
             return
 
     delete_all_persistent_files()
+    # Update the PersistentConfigurationManager's cached configurations to account for the clean
+    PersistentConfigurationManager.read_configurations()

--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -244,4 +244,4 @@ def delete_all_files(
     delete_all_persistent_files()
     # Update the PersistentConfigurationManager's cached configurations to account for the clean
     PersistentSessionManager.unset_active_session()
-    PersistentConfigurationManager.read_configurations()
+    PersistentConfigurationManager.reset()

--- a/src/aerie_cli/commands/configurations.py
+++ b/src/aerie_cli/commands/configurations.py
@@ -243,5 +243,5 @@ def delete_all_files(
 
     delete_all_persistent_files()
     # Update the PersistentConfigurationManager's cached configurations to account for the clean
-    PersistentSessionManager.unset_active_session()
+    PersistentSessionManager.reset()
     PersistentConfigurationManager.reset()

--- a/src/aerie_cli/persistent.py
+++ b/src/aerie_cli/persistent.py
@@ -200,6 +200,19 @@ class PersistentSessionManager:
         cls._active_session = None
         return name
 
+    @classmethod
+    def reset(cls) -> None:
+        cls._active_session = None
+
+        # Get any/all open sessions. List in chronological order, newest first
+        fs: List[Path] = [
+            f for f in SESSION_FILE_DIRECTORY.glob('*.aerie_cli.session')]
+        if not len(fs):
+            return
+        # Delete all session files
+        for fn in fs:
+            fn.unlink()
+
 
 class NoActiveSessionError(Exception):
     pass

--- a/src/aerie_cli/persistent.py
+++ b/src/aerie_cli/persistent.py
@@ -103,6 +103,10 @@ class PersistentConfigurationManager:
         else:
             cls._configurations = []
 
+    @classmethod
+    def reset(cls) -> None:
+        cls._configurations = None
+
 
 class PersistentSessionManager:
     _active_session = None


### PR DESCRIPTION
`PersistentConfigurationManager` will read the persistent files only once for each instance of the program. This is not usually a problem when using the CLI. However, if a user were to call `clean` through the API, `PersistentConfigurationManager`'s cached configurations would not be updated. This means that subsequent calls using a CLI runner to `configurations list`, or any API functions would not read the change to the persistent configurations.

Note that this is not a problem in the other functions that alter the persistent files, since they change `PersistentConfigurationManager`'s cached configurations accordingly.

To resolve this, `clean` now makes `PersistentConfigurationManager` re-read the persistent files after deleting them. Additionally, the active session is now unset.