### PR TITLE
Get resource types from table instead of deprecated Action

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1664,8 +1664,8 @@ class AerieClient:
         """
 
         get_resource_types_query = """
-        query ResourceTypes($missionModelId: ID!) {
-            resourceTypes(missionModelId: $missionModelId) {
+        query ResourceTypes($missionModelId: Int!) {
+            resourceTypes: resource_type(where: {model_id: {_eq: $missionModelId}}) {
                 name
                 schema
             }

--- a/tests/unit_tests/files/mock_responses/get_resource_types.json
+++ b/tests/unit_tests/files/mock_responses/get_resource_types.json
@@ -1,7 +1,7 @@
 [
     {
         "request": {
-            "query": "query ResourceTypes($missionModelId: ID!) { resourceTypes(missionModelId: $missionModelId) { name schema } }",
+            "query": "query ResourceTypes($missionModelId: Int!) { resourceTypes: resource_type(where: {model_id: {_eq: $missionModelId}}) { name schema } }",
             "variables": {
                 "missionModelId": 1
             }


### PR DESCRIPTION
As of Aerie v1.8.0, the `resourceTypes` action has been deprecated in favor of querying the `resource_type` table.

This PR was tested by running the CLI against a dev version of Aerie and verifying that the results of the `get_resource_types` is exactly the same after the change.