### PR TITLE
Bugfixes: importlib-metadata dependency and README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Aerie CLI provides a command-line interface and user-extendable Python backend f
 
 This short procedure will get you up and running with the basics of Aerie CLI. Read the following sections for more information.
 
-1. Install/update to Python 3.9
+1. Install/update to Python >=3.9
 
 2. Install Aerie CLI from Github:
 
    ```sh
-   python3 -m pip install git+https://github.com/NASA-AMMOS/aerie-cli.git#main
+   python3 -m pip install git+https://github.com/NASA-AMMOS/aerie-cli.git@main
    ```
 
 3. Configure access to an Aerie host

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ rich = "^12.6.0"
 dataclasses-json = "^0.5.6"
 pandas = "^1.5.1"
 appdirs = "^1.4.4"
+importlib-metadata = "^4.8.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aerie-cli"
-version = "1.2.1"
+version = "1.2.2"
 description = "aerie-cli"
 authors = ["Gavin Martin <gavin.c.martin@jpl.nasa.gov>", "Mihir Kamble <mihir.m.kamble@jpl.nasa.gov>"]
 license = "MIT"


### PR DESCRIPTION
Declare the `importlib-metadata` dependency necessary to get the package version for Python < 3.10. Also update the README to actually install from `main`, instead of the old syntax which would just install from the repo default branch (which I changed to `develop`). 