### PR TITLE
Hotfixes: Missed name change and permissions nuance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aerie-cli"
-version = "2.0.0"
+version = "2.0.1"
 description = "A CLI application and Python API for interacting with Aerie."
 authors = []
 license = "MIT"

--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -265,9 +265,7 @@ class AerieClient:
         activity_to_update: Activity,
         plan_id: int
     ) -> int:
-        activity_dict: Dict = activity_to_update.to_api_create(
-                plan_id
-            ).to_dict()
+        activity_dict: Dict = activity_to_update.to_api_update().to_dict()
         update_activity_mutation = """
         mutation UpdateActvityDirective($id: Int!, $plan_id: Int!, $activity: activity_directive_set_input!) {
             updateActivity: update_activity_directive_by_pk(

--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1569,11 +1569,11 @@ class AerieClient:
                 """
                 resp = self.aerie_host.post_to_graphql(
                     query,
-                    args=activity.parameters,
+                    args=activity.arguments,
                     act_type=activity.type,
                     model_id=plan.model_id,
                 )
-                activity.parameters = ApiEffectiveActivityArguments.from_dict(
+                activity.arguments = ApiEffectiveActivityArguments.from_dict(
                     resp).arguments
         return plan
 

--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1562,7 +1562,6 @@ class AerieClient:
                     )
                     {
                         arguments
-                        errors
                         success
                     }
                 }

--- a/src/aerie_cli/schemas/api.py
+++ b/src/aerie_cli/schemas/api.py
@@ -53,6 +53,7 @@ class ApiSerialize:
 @define
 class ApiEffectiveActivityArguments(ApiSerialize):
     arguments: Dict[str, Any]
+    success: bool
 
 @define
 class ActivityBase(ApiSerialize):

--- a/src/aerie_cli/schemas/api.py
+++ b/src/aerie_cli/schemas/api.py
@@ -94,6 +94,16 @@ class ApiActivityCreate(ActivityBase):
 
 
 @define
+class ApiActivityUpdate(ActivityBase):
+    """Format for updating activity directives
+
+    Plan ID is excluded as this column has restricted permissions for update
+    """
+
+    pass
+
+
+@define
 class ApiActivityRead(ActivityBase):
     """Format for downloading activity directives
 

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -18,6 +18,7 @@ from attrs import asdict
 
 from aerie_cli.utils.serialization import parse_timedelta_str
 from aerie_cli.schemas.api import ApiActivityCreate
+from aerie_cli.schemas.api import ApiActivityUpdate
 from aerie_cli.schemas.api import ApiActivityPlanCreate
 from aerie_cli.schemas.api import ApiActivityPlanRead
 from aerie_cli.schemas.api import ApiActivityRead
@@ -70,6 +71,17 @@ class Activity(ActivityBase, ClientSerialize):
         return ApiActivityCreate(
             type=self.type,
             plan_id=plan_id,
+            start_offset=self.start_offset,
+            arguments=self.arguments,
+            name=self.name,
+            metadata=self.metadata,
+            anchor_id=self.anchor_id,
+            anchored_to_start=self.anchored_to_start
+        )
+
+    def to_api_update(self):
+        return ApiActivityUpdate(
+            type=self.type,
             start_offset=self.start_offset,
             arguments=self.arguments,
             name=self.name,

--- a/tests/integration_tests/test_plans.py
+++ b/tests/integration_tests/test_plans.py
@@ -139,6 +139,24 @@ def test_plan_download():
         f"{result.stderr}"
     assert f"Wrote activity plan" in result.stdout
 
+def test_plan_download_expanded_args():
+    """
+    Download a plan, exercising the --full-args option to get effective activity arguments
+    """
+    result = runner.invoke(
+        app,
+        ["plans", "download", "--full-args", "true"],
+        input=str(plan_id) + "\n" + DOWNLOADED_FILE_NAME + "\n",
+        catch_exceptions=False,
+    )
+    path_to_plan = Path(DOWNLOADED_FILE_NAME)
+    assert path_to_plan.exists()
+    path_to_plan.unlink()
+    assert result.exit_code == 0,\
+        f"{result.stdout}"\
+        f"{result.stderr}"
+    assert f"Wrote activity plan" in result.stdout
+
 def test_plan_download_resources():
     result = runner.invoke(
         app,

--- a/tests/unit_tests/files/mock_responses/update_activity.json
+++ b/tests/unit_tests/files/mock_responses/update_activity.json
@@ -14,8 +14,7 @@
                         "aParameter": "2030-001T00:00:00Z"
                     },
                     "anchor_id": null,
-                    "anchored_to_start": true,
-                    "plan_id": 1
+                    "anchored_to_start": true
                 }
             }
         },


### PR DESCRIPTION
Two bug fixes found after the 2.0.0 release:

- Fixes a lingering reference to `Activity.parameters` (since replaced with `Activity.arguments` to align with Aerie conventions) and correct the fields in the data class and query. Adds a test that exercises the `--full-args` option for `plans download`. 
- Removes PK `plan_id` from activity updates because even "aerie_admin" doesn't have permissions. Updates corresponding unit test and tested against an Aerie instance.