### PR TITLE
Add commands for plan collaborators

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -1761,3 +1761,75 @@ class AerieClient:
             key=key
         )
         return resp["key"]
+
+    def list_plan_collaborators(self, plan_id: int) -> list:
+        """List plan collaborators
+
+        Args:
+            plan_id (int): ID of Plan to list collaborators of
+
+        Returns:
+            list[str]: List of collaborator usernames
+        """
+        query = """
+        query GetPlanCollaborators($plan_id: Int!) {
+            plan_by_pk(id: $plan_id) {
+                collaborators {
+                    collaborator
+                }
+            }
+        }
+        """
+
+        resp = self.aerie_host.post_to_graphql(
+            query,
+            plan_id=plan_id
+        )
+        return [c["collaborator"] for c in resp["collaborators"]]
+
+    def add_plan_collaborator(self, plan_id: int, user: str):
+        """Add a plan collaborator
+
+        Args:
+            plan_id (int): ID of plan to add collaborator to
+            user (str): Username of collaborator
+        """
+        query = """
+        mutation addPlanCollaborator($plan_id: Int!, $collaborator: String!) {
+            insert_plan_collaborators_one(object: {plan_id: $plan_id, collaborator: $collaborator}) {
+                collaborator
+            }
+        }
+        """
+
+        self.aerie_host.post_to_graphql(
+            query,
+            plan_id=plan_id,
+            collaborator=user
+        )
+
+    def delete_plan_collaborator(self, plan_id: int, user: str):
+        """Delete a plan collaborator
+
+        Args:
+            plan_id (int): ID of the plan to delete a collaborator from
+            user (str): Username of the collaborator
+        """
+
+        query = """
+        mutation DeletePlanCollaborator($plan_id: Int!, $collaborator: String!) {
+            delete_plan_collaborators_by_pk(collaborator: $collaborator, plan_id: $plan_id) {
+                collaborator
+                plan_id
+            }
+        }
+        """
+
+        resp = self.aerie_host.post_to_graphql(
+            query,
+            plan_id=plan_id,
+            collaborator=user
+        )
+
+        if resp is None:
+            raise RuntimeError(f"Failed to delete plan collaborator")

--- a/src/aerie_cli/app.py
+++ b/src/aerie_cli/app.py
@@ -27,7 +27,7 @@ from aerie_cli.utils.sessions import (
 from aerie_cli.utils.configurations import find_configuration
 
 app = typer.Typer()
-app.add_typer(plans.app, name="plans")
+app.add_typer(plans.plans_app, name="plans")
 app.add_typer(models.app, name="models")
 app.add_typer(configurations.app, name="configurations")
 app.add_typer(expansion.app, name="expansion")

--- a/src/aerie_cli/app.py
+++ b/src/aerie_cli/app.py
@@ -85,6 +85,9 @@ def activate_session(
     name: str = typer.Option(
         None, "--name", "-n", help="Name for this configuration", metavar="NAME"
     ),
+    username: str = typer.Option(
+        None, "--username", "-u", help="Specify/override configured Aerie username", metavar="USERNAME"
+    ),
     role: str = typer.Option(
         None, "--role", "-r", help="Specify a non-default role", metavar="ROLE"
     )
@@ -99,7 +102,7 @@ def activate_session(
 
     conf = PersistentConfigurationManager.get_configuration_by_name(name)
 
-    session = start_session_from_configuration(conf)
+    session = start_session_from_configuration(conf, username)
 
     if role is not None:
         if role in session.aerie_jwt.allowed_roles:

--- a/src/aerie_cli/commands/plans.py
+++ b/src/aerie_cli/commands/plans.py
@@ -9,11 +9,14 @@ from rich.table import Table
 
 from aerie_cli.commands.command_context import CommandContext
 from aerie_cli.schemas.client import ActivityPlanCreate
+from aerie_cli.utils.prompts import select_from_list
 
-app = typer.Typer()
+plans_app = typer.Typer()
+collaborators_app = typer.Typer()
+plans_app.add_typer(collaborators_app, name="collaborators")
 
 
-@app.command()
+@plans_app.command()
 def download(
     id: int = typer.Option(..., "--plan-id", "--id", "-p", help="Plan ID", prompt=True),
     full_args: str = typer.Option(
@@ -29,7 +32,7 @@ def download(
     typer.echo(f"Wrote activity plan to {output}")
 
 
-@app.command()
+@plans_app.command()
 def download_simulation(
     sim_id: int = typer.Option(
         ..., '--sim-id', '-s',
@@ -48,7 +51,7 @@ def download_simulation(
         typer.echo(f"Wrote activity plan to {output}")
 
 
-@app.command()
+@plans_app.command()
 def download_resources(
     sim_id: int = typer.Option(
         ..., '--sim-id', '-s',
@@ -157,7 +160,7 @@ def download_resources(
             typer.echo(f"Wrote resource timelines to {output}")
 
 
-@app.command()
+@plans_app.command()
 def upload(
     input: str = typer.Option(
         ..., "--input", "-i", help="The input file from which to create an Aerie plan", prompt=True
@@ -179,7 +182,7 @@ def upload(
     typer.echo(f"Created plan ID: {plan_id}")
 
 
-@app.command()
+@plans_app.command()
 def duplicate(
     id: int = typer.Option(..., "--plan-id", "--id", "-p", help="Plan ID", prompt=True),
     duplicated_plan_name: str = typer.Option(
@@ -196,7 +199,7 @@ def duplicate(
     typer.echo(f"Duplicate activity plan created with ID: {duplicated_plan_id}")
 
 
-@app.command()
+@plans_app.command()
 def simulate(
     id: int = typer.Option(..., help="Plan ID", prompt=True),
     output: Union[str, None] = typer.Option(
@@ -223,7 +226,7 @@ def simulate(
         typer.echo(f"Wrote simulation results to {output}")
 
 
-@app.command()
+@plans_app.command()
 def list():
     """List uploaded plans."""
 
@@ -257,7 +260,7 @@ def list():
     Console().print(table)
 
 
-@app.command()
+@plans_app.command()
 def create_config(
     plan_id: int = typer.Option(..., help="Plan ID", prompt=True),
     arg_file: str = typer.Option(
@@ -275,7 +278,7 @@ def create_config(
         typer.echo(f"(*) {arg}: {resp[arg]}")
 
 
-@app.command()
+@plans_app.command()
 def update_config(
     plan_id: int = typer.Option(..., help="Plan ID", prompt=True),
     arg_file: str = typer.Option(
@@ -294,7 +297,7 @@ def update_config(
         typer.echo(f"(*) {arg}: {resp[arg]}")
 
 
-@app.command()
+@plans_app.command()
 def delete(
     plan_id: int = typer.Option(..., "--plan-id", "-p", help="Plan ID to be deleted", prompt=True),
 ):
@@ -304,7 +307,7 @@ def delete(
     typer.echo(f"Plan `{plan_name}` with ID: {plan_id} has been removed.")
 
 
-@app.command()
+@plans_app.command()
 def clean():
     """Delete all activity plans."""
     client = CommandContext.get_client()
@@ -315,3 +318,56 @@ def clean():
 
     typer.echo(f"All activity plans have been deleted")
 
+@collaborators_app.command("list")
+def list_collaborators(
+    plan_id: int = typer.Option(
+        ..., "--plan-id", "-p", help="Plan ID to list collaborators of", prompt="Plan ID"
+    )
+):
+    client = CommandContext.get_client()
+
+    collaborators = client.list_plan_collaborators(plan_id)
+    if len(collaborators):
+        typer.echo("\n".join(collaborators))
+    else:
+        typer.echo("No collaborators")
+
+
+@collaborators_app.command("add")
+def add_collaborator(
+    plan_id: int = typer.Option(
+        ..., "--plan-id", "-p", help="Plan ID to add collaborator", prompt="Plan ID"
+    ),
+    user: str = typer.Option(
+        ..., "--user", "-u", help="Username of collaborator to add", prompt="Collaborator Username"
+    ),
+):
+    client = CommandContext.get_client()
+
+    client.add_plan_collaborator(plan_id, user)
+    if user in client.list_plan_collaborators(plan_id):
+        typer.echo(f"Successfully added collaborator: {user}")
+    else:
+        typer.echo(f"Failed to add collaborator")
+
+
+@collaborators_app.command("delete")
+def delete_collaborator(
+    plan_id: int = typer.Option(
+        ..., "--plan-id", "-p", help="Plan ID to delete collaborator from", prompt="Plan ID"
+    ),
+    user: str = typer.Option(
+        None, "--user", "-u", help="Username of collaborator to delete"
+    ),
+):
+    client = CommandContext.get_client()
+
+    if user is None:
+        collaborators = client.list_plan_collaborators(plan_id)
+        user = select_from_list(collaborators, "Select a collaborator to remove")
+    client.delete_plan_collaborator(plan_id, user)
+
+    if user not in client.list_plan_collaborators(plan_id):
+        typer.echo("Successfully deleted collaborator")
+    else:
+        typer.echo("Failed to delete collaborator")

--- a/src/aerie_cli/utils/sessions.py
+++ b/src/aerie_cli/utils/sessions.py
@@ -153,10 +153,11 @@ def start_session_from_configuration(
         configuration.name,
     )
 
-    if configuration.username is None:
-        username = typer.prompt("Aerie Username")
-    else:
-        username = configuration.username
+    if username is None:
+        if configuration.username is None:
+            username = typer.prompt("Aerie Username")
+        else:
+            username = configuration.username
 
     if password is None and hs.is_auth_enabled():
         password = typer.prompt("Aerie Password", hide_input=True)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -5,50 +5,65 @@ import os
 import sys
 
 from aerie_cli.aerie_client import AerieClient
-from aerie_cli.aerie_host import AerieHost
+from aerie_cli.aerie_host import AerieHost, AerieHostConfiguration
 from aerie_cli.commands.configurations import (
     delete_all_persistent_files,
     upload_configurations,
 )
-from aerie_cli.app import deactivate_session, activate_session
-from aerie_cli.utils.sessions import get_active_session_client
+from aerie_cli.app import deactivate_session
+from aerie_cli.persistent import PersistentConfigurationManager, PersistentSessionManager
+from aerie_cli.utils.sessions import (
+    get_active_session_client,
+    start_session_from_configuration,
+)
 
 # in case src_path is not from aeri-cli src and from site-packages
 src_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../src")
 sys.path.insert(0, src_path)
 
+# Configuration values mirror those in the test file localhost_config.json
 GRAPHQL_URL = "http://localhost:8080/v1/graphql"
 GATEWAY_URL = "http://localhost:9000"
 USERNAME = "a"
 PASSWORD = "a"
+ANONYMOUS_LOCALHOST_CONF = AerieHostConfiguration("localhost", GRAPHQL_URL, GATEWAY_URL)
+
+# Additional usernames to register with Aerie
+ADDITIONAL_USERS = ["user1", "user2", "user3"]
+
 # This should only ever be set to the admin secret for a local instance of aerie
 HASURA_ADMIN_SECRET = os.environ.get("HASURA_GRAPHQL_ADMIN_SECRET")
 
-aerie_host = AerieHost(GRAPHQL_URL, GATEWAY_URL)
-aerie_host.authenticate(USERNAME, PASSWORD)
-aerie_host.change_role("aerie_admin")
-client = AerieClient(aerie_host)
-
+# Test constants
 DOWNLOADED_FILE_NAME = "downloaded_file.test"
-
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
-
 FILES_PATH = os.path.join(TEST_DIR, "files")
-
-# Configuration Variables
 CONFIGURATIONS_PATH = os.path.join(FILES_PATH, "configuration")
 CONFIGURATION_PATH = os.path.join(CONFIGURATIONS_PATH, "localhost_config.json")
+
+# Login to add additional users to the `users` table
+for username in ADDITIONAL_USERS:
+    start_session_from_configuration(
+        ANONYMOUS_LOCALHOST_CONF,
+        username
+    )
 
 # Resets the configurations and adds localhost
 deactivate_session()
 delete_all_persistent_files()
 upload_configurations(CONFIGURATION_PATH)
-activate_session("localhost")
-persisent_client = None
+
+# Login as the main username, set role, and store session as persistent
+localhost_conf = PersistentConfigurationManager.get_configuration_by_name("localhost")
+aerie_host = start_session_from_configuration(localhost_conf, USERNAME, PASSWORD)
+aerie_host.change_role("aerie_admin")
+PersistentSessionManager.set_active_session(aerie_host)
+
+client = None
 try:
-    persisent_client = get_active_session_client()
+    client = get_active_session_client()
 except:
     raise RuntimeError("Configuration is not active!")
 assert (
-    persisent_client.aerie_host.gateway_url == GATEWAY_URL
+    client.aerie_host.gateway_url == GATEWAY_URL
 ), "Aerie instances are mismatched. Ensure test URLs are the same."

--- a/tests/integration_tests/test_constraints.py
+++ b/tests/integration_tests/test_constraints.py
@@ -1,6 +1,6 @@
 from typer.testing import CliRunner
 
-from .conftest import client, HASURA_ADMIN_SECRET
+from .conftest import client
 from aerie_cli.__main__ import app
 
 from aerie_cli.schemas.client import ActivityPlanCreate

--- a/tests/integration_tests/test_expansion.py
+++ b/tests/integration_tests/test_expansion.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from aerie_cli.__main__ import app
 from aerie_cli.schemas.client import ActivityPlanCreate
 
-from .conftest import client, HASURA_ADMIN_SECRET
+from .conftest import client
 
 runner = CliRunner(mix_stderr = False)
 

--- a/tests/integration_tests/test_metadata.py
+++ b/tests/integration_tests/test_metadata.py
@@ -1,6 +1,5 @@
 from typer.testing import CliRunner
 
-from .conftest import client, HASURA_ADMIN_SECRET
 from aerie_cli.__main__ import app
 
 import os

--- a/tests/integration_tests/test_models.py
+++ b/tests/integration_tests/test_models.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from aerie_cli.__main__ import app
 
-from .conftest import client, HASURA_ADMIN_SECRET
+from .conftest import client
 
 runner = CliRunner(mix_stderr = False)
 

--- a/tests/integration_tests/test_scheduling.py
+++ b/tests/integration_tests/test_scheduling.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from aerie_cli.__main__ import app
 from aerie_cli.schemas.client import ActivityPlanCreate
 
-from .conftest import client, HASURA_ADMIN_SECRET
+from .conftest import client
 
 runner = CliRunner(mix_stderr = False)
 


### PR DESCRIPTION
Adds sub-commands to plans to `create`/`list`/`delete` plan collaborators, along with implementing the relevant queries in `AerieClient`. 

Implements integration test cases which required some additions to the integration test infrastructure:
- I implemented a `username` override in `start_session_from_configuration` in order to log in with several usernames, so I added the override to the `activate` command, as well
- Removed unused imports across the integration tests while I was updating import statements
- Updated a few names and (hopefully) cleared up `conftest.py`

Closes #84 