### PR TITLE
Trivial change to help message for plan download_resources

### DIFF
--- a/src/aerie_cli/commands/plans.py
+++ b/src/aerie_cli/commands/plans.py
@@ -66,7 +66,7 @@ def download_resources(
         False, "--absolute-time", help="Change relative timestamps to absolute"
     ),
     specific_states: str = typer.Option(
-        None, help="The file with the specific states [defaults to all]"
+        None, help="The file with the specific states, one state per line [defaults to all]"
     )
 ):
     """


### PR DESCRIPTION
I didn't know what the file format was for the the input list of resources to download. It would be nice for cases you just want a resource or two to list those resources directly in the command line, but I didn't address that. 