### PR TITLE
Provide client method for simulation dataset metadata

### DIFF
--- a/src/aerie_cli/commands/expansion.py
+++ b/src/aerie_cli/commands/expansion.py
@@ -72,8 +72,8 @@ def list_expansion_runs(
     client = CommandContext.get_client()
 
     if simulation_dataset_id is None:
-        simulation_datasets = client.get_simulation_dataset_ids_by_plan_id(
-            plan_id)
+        simulation_datasets = [
+            d.id for d in client.list_simulation_datasets_by_plan_id(plan_id)]
         table_caption = f'All runs for Plan ID {plan_id}'
     else:
         simulation_datasets = [simulation_dataset_id]
@@ -132,8 +132,8 @@ def list_sequences(
     client = CommandContext.get_client()
 
     if simulation_dataset_id is None:
-        simulation_datasets = client.get_simulation_dataset_ids_by_plan_id(
-            plan_id)
+        simulation_datasets = [
+            d.id for d in client.list_simulation_datasets_by_plan_id(plan_id)]
         table_caption = f'All sequences for Plan ID {plan_id}'
     else:
         simulation_datasets = [simulation_dataset_id]

--- a/src/aerie_cli/commands/plans.py
+++ b/src/aerie_cli/commands/plans.py
@@ -242,9 +242,9 @@ def list():
     table.add_column("Latest Sim. Dataset ID", no_wrap=True)
     table.add_column("Model ID", no_wrap=True)
     for activity_plan in resp:
-        sim_ids = client.get_simulation_dataset_ids_by_plan_id(activity_plan.id)
+        sim_ids = client.list_simulation_datasets_by_plan_id(activity_plan.id)
         if len(sim_ids):
-            simulation_dataset_id = str(max(sim_ids))
+            simulation_dataset_id = str(sim_ids[0].id)
         else:
             simulation_dataset_id = ''
             

--- a/src/aerie_cli/schemas/api.py
+++ b/src/aerie_cli/schemas/api.py
@@ -191,3 +191,32 @@ class ApiMissionModelCreate(ApiSerialize):
 @define
 class ApiMissionModelRead(ApiMissionModelCreate):
     id: int
+
+
+@define
+class ApiSimulationDatasetRead(ApiSerialize):
+    id: int
+    simulation_id: int
+    dataset_id: int
+    offset_from_plan_start: timedelta = field(
+        converter=convert_to_time_delta
+    )
+    plan_revision: int
+    model_revision: int
+    simulation_template_revision: int
+    simulation_revision: int
+    dataset_revision: int
+    arguments: Dict[str, Any]
+    simulation_start_time: Arrow = field(
+        converter=arrow.get
+    )
+    simulation_end_time: Arrow = field(
+        converter=arrow.get
+    )
+    status: str
+    reason: str
+    canceled: bool
+    requested_by: str
+    requested_at: Arrow = field(
+        converter=arrow.get
+    )

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -26,6 +26,7 @@ from aerie_cli.schemas.api import ApiAsSimulatedActivity
 from aerie_cli.schemas.api import ApiResourceSampleResults
 from aerie_cli.schemas.api import ApiSimulatedResourceSample
 from aerie_cli.schemas.api import ApiSimulationResults
+from aerie_cli.schemas.api import ApiSimulationDatasetRead
 from aerie_cli.schemas.api import ActivityBase
 
 def parse_timedelta_str_converter(t) -> timedelta:
@@ -370,3 +371,45 @@ class ExpansionRule(ClientSerialize):
 class ResourceType(ClientSerialize):
     name: str
     schema: Dict
+
+@define
+class SimulationDataset(ClientSerialize):
+    id: int
+    simulation_id: int
+    dataset_id: int
+    offset_from_plan_start: timedelta
+    plan_revision: int
+    model_revision: int
+    simulation_template_revision: int
+    simulation_revision: int
+    dataset_revision: int
+    arguments: Dict[str, Any]
+    simulation_start_time: Arrow
+    simulation_end_time: Arrow
+    status: str
+    reason: str
+    canceled: bool
+    requested_by: str
+    requested_at: Arrow
+
+    @classmethod
+    def from_api_read(cls, api_sim_dataset: ApiSimulationDatasetRead) -> "SimulationDataset":
+        return SimulationDataset(
+            id=api_sim_dataset.id,
+            simulation_id=api_sim_dataset.simulation_id,
+            dataset_id=api_sim_dataset.dataset_id,
+            offset_from_plan_start=api_sim_dataset.offset_from_plan_start,
+            plan_revision=api_sim_dataset.plan_revision,
+            model_revision=api_sim_dataset.model_revision,
+            simulation_template_revision=api_sim_dataset.simulation_template_revision,
+            simulation_revision=api_sim_dataset.simulation_revision,
+            dataset_revision=api_sim_dataset.dataset_revision,
+            arguments=api_sim_dataset.arguments,
+            simulation_start_time=api_sim_dataset.simulation_start_time,
+            simulation_end_time=api_sim_dataset.simulation_end_time,
+            status=api_sim_dataset.status,
+            reason=api_sim_dataset.reason,
+            canceled=api_sim_dataset.canceled,
+            requested_by=api_sim_dataset.requested_by,
+            requested_at=api_sim_dataset.requested_at
+        )

--- a/tests/integration_tests/test_plans.py
+++ b/tests/integration_tests/test_plans.py
@@ -186,9 +186,9 @@ def test_delete_collaborators():
 
 def test_plan_simulate():
     result = cli_plan_simulate()
-    sim_ids = client.get_simulation_dataset_ids_by_plan_id(plan_id)
+    sim_ids = client.list_simulation_datasets_by_plan_id(plan_id)
     global sim_id
-    sim_id = sim_ids[-1]
+    sim_id = sim_ids[0].id
     assert result.exit_code == 0,\
         f"{result.stdout}"\
         f"{result.stderr}"


### PR DESCRIPTION
Replace get_simulation_dataset_ids_by_plan_id with list_simulation_datasets_by_plan_id.

The new method returns a list of objects, each containing all the metadata for a simulation dataset, rather than just the id. The old method is marked as deprecated and re-implemented as a wrapper around the new method.

Additionally, this adds an API data class and a client data class defining a simulation dataset.

This change was tested by running all unit and integration tests.