### PR TITLE
Develop branch version tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aerie-cli"
-version = "2.0.1"
+version = "0.0.0-dev0"
 description = "A CLI application and Python API for interacting with Aerie."
 authors = []
 license = "MIT"


### PR DESCRIPTION
Sets a semantic-versioning-friendly tag to clearly differentiate non-release builds.