### PR TITLE
Command Expansion Deploy Tool

### DIFF
--- a/src/aerie_cli/aerie_client.py
+++ b/src/aerie_cli/aerie_client.py
@@ -853,6 +853,8 @@ class AerieClient:
         activity_name: str,
         model_id: str,
         command_dictionary_id: str,
+        name: str = None,
+        description: str = None
     ) -> int:
         """Submit expansion logic to an Aerie instance
 
@@ -861,34 +863,31 @@ class AerieClient:
             activity_name (str): Name of the activity
             model_id (str): Aerie model ID
             command_dictionary_id (str): Aerie command dictionary ID
+            name (str, Optional): Name of the expansion rule
+            description (str, Optional): Description of the expansion rule
 
         Returns:
             int: Expansion Rule ID in Aerie
         """
 
         create_expansion_logic_query = """
-        mutation UploadExpansionLogic(
-            $activity_type_name: String!
-            $expansion_logic: String!
-            $command_dictionary_id: Int!
-            $mission_model_id: Int!
-        ) {
-            addCommandExpansionTypeScript(
-                activityTypeName: $activity_type_name
-                expansionLogic: $expansion_logic
-                authoringCommandDictionaryId: $command_dictionary_id
-                authoringMissionModelId: $mission_model_id
-            ) {
+        mutation CreateExpansionRule($rule: expansion_rule_insert_input!) {
+            createExpansionRule: insert_expansion_rule_one(object: $rule) {
                 id
             }
         }
         """
+        rule = {
+            "activity_type": activity_name,
+            "authoring_command_dict_id": command_dictionary_id,
+            "authoring_mission_model_id": model_id,
+            "expansion_logic": expansion_logic,
+            "name": name if (name is not None) else activity_name + arrow.utcnow().format("_YYYY-MM-DDTHH-mm-ss"),
+            "description": description if (description is not None) else ""
+        }
         data = self.aerie_host.post_to_graphql(
             create_expansion_logic_query,
-            activity_type_name=activity_name,
-            expansion_logic=expansion_logic,
-            mission_model_id=model_id,
-            command_dictionary_id=command_dictionary_id,
+            rule=rule
         )
 
         return data["id"]

--- a/src/aerie_cli/schemas/client.py
+++ b/src/aerie_cli/schemas/client.py
@@ -392,3 +392,28 @@ class ExpansionRule(ClientSerialize):
 class ResourceType(ClientSerialize):
     name: str
     schema: Dict
+
+
+@define
+class ExpansionDeployRule(ClientSerialize):
+    name: str
+    activity_type: str
+    file_name: str
+
+
+@define
+class ExpansionDeploySet(ClientSerialize):
+    name: str
+    rules: List[str]
+
+
+@define
+class ExpansionDeployConfiguration(ClientSerialize):
+    rules: List[ExpansionDeployRule] = field(
+        converter=converters.optional(
+            lambda x: [ExpansionDeployRule.from_dict(d) if isinstance(d, dict) else d for d in x])
+    )
+    sets: List[ExpansionDeploySet] = field(
+        converter=converters.optional(
+            lambda x: [ExpansionDeploySet.from_dict(d) if isinstance(d, dict) else d for d in x])
+    )

--- a/tests/integration_tests/files/expansion/BakeBananaBread_exp.ts
+++ b/tests/integration_tests/files/expansion/BakeBananaBread_exp.ts
@@ -1,0 +1,6 @@
+export default function MyExpansion(props: {
+    activityInstance: ActivityType
+}): ExpansionReturn {
+    const { activityInstance } = props
+    return []
+}

--- a/tests/integration_tests/files/expansion/BiteBanana_exp.ts
+++ b/tests/integration_tests/files/expansion/BiteBanana_exp.ts
@@ -1,0 +1,6 @@
+export default function MyExpansion(props: {
+    activityInstance: ActivityType
+}): ExpansionReturn {
+    const { activityInstance } = props
+    return []
+}

--- a/tests/integration_tests/files/expansion/expansion_deploy_config.json
+++ b/tests/integration_tests/files/expansion/expansion_deploy_config.json
@@ -1,0 +1,28 @@
+{
+    "rules": [
+        {
+            "name": "integration_test_BakeBananaBread",
+            "activity_type": "BakeBananaBread",
+            "file_name": "BakeBananaBread_exp.ts"
+        },
+        {
+            "name": "integration_test_BiteBanana",
+            "activity_type": "BiteBanana",
+            "file_name": "BiteBanana_exp.ts"
+        },
+        {
+            "name": "integration_test_bad",
+            "activity_type": "Fake",
+            "file_name": "this path no exist"
+        }
+    ],
+    "sets": [
+        {
+            "name": "integration_test_set",
+            "rules": [
+                "integration_test_BakeBananaBread",
+                "integration_test_BiteBanana"
+            ]
+        }
+    ]
+}

--- a/tests/integration_tests/test_expansion.py
+++ b/tests/integration_tests/test_expansion.py
@@ -37,6 +37,8 @@ command_dictionary_id = -1
 # Expansion Variables
 expansion_set_id = -1
 expansion_sequence_id = 1
+EXPANSION_FILES_PATH = os.path.join(FILES_PATH, "expansion")
+EXPANSION_DEPLOY_CONFIG_PATH = os.path.join(EXPANSION_FILES_PATH, "expansion_deploy_config.json")
 
 @pytest.fixture(scope="module", autouse=True)
 def set_up_environment(request):
@@ -126,6 +128,33 @@ def test_expansion_sequence_delete():
 # TEST EXPANSION SETS
 # Uses model, command dictionary, and activity types
 #######################
+
+
+def test_expansion_deploy():
+    result = runner.invoke(
+        app,
+        [
+            "expansion",
+            "deploy",
+            "-m",
+            str(model_id),
+            "-d",
+            str(command_dictionary_id),
+            "-c",
+            EXPANSION_DEPLOY_CONFIG_PATH,
+            "--rules-path",
+            EXPANSION_FILES_PATH,
+            "--time-tag"
+        ],
+        catch_exceptions=False
+    )
+    assert result.exit_code == 0, \
+        f"{result.stdout}"\
+        f"{result.stderr}"
+    assert "Created expansion rule integration_test_BakeBananaBread" in result.stdout
+    assert "Created expansion rule integration_test_BiteBanana" in result.stdout
+    assert "Failed to create expansion rule integration_test_bad" in result.stdout
+    assert "Created expansion set integration_test_set" in result.stdout
 
 def test_expansion_set_create():
     client.create_expansion_rule(


### PR DESCRIPTION
* Added `aerie-cli expansion deploy` command to bulk deploy expansion rules and sets according to a configuration file
* Updated `AerieClient.create_expansion_rule` to match the latest Aerie implementation, including support for rule names and proper assignment of the rule author

Closes #115 