### PR TITLE
Feature/more external auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ In this example, the user would be prompted to enter a value for "password" and,
 Additional `external_auth` settings for providers that require non standard communication pattern
 |Key|Type|Description|Default|
 |:--|:---|:----------|-------|
-|`data_as_headers`|boolean|Send post_vars as request headers instead of body|False|
-|`token_cookie_mappings`|List of Dict|Map tokens in response body to session cookies|[]|
-|`secret_prompt_mappings`|Dict|Prompt for secret_post_vars with more descriptive names|{}|
+|`data_as_headers`|`boolean`|Send post_vars as request headers instead of body|`False`|
+|`token_cookie_mappings`|`list` of `dict`|Map tokens in response body to session cookies|`[]`|
+|`secret_prompt_mappings`|`dict`|Prompt for `secret_post_vars` with more descriptive names|`{}`|
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -219,10 +219,11 @@ In this example, the user would be prompted to enter a value for "password" and,
 ```
 Additional `external_auth` settings for providers that require non standard communication pattern
 |Key|Type|Description|Default|
-|---|----|-----------|-------|
-|data_as_headers|boolean|Send post_vars as request headers instead of body|False|
-|token_cookie_mappings|List of Dict|Map tokens in response body to session cookies|[]|
-|secret_prompt_mappings|Dict|Prompt for secret_post_vars with more descriptive names|
+|:--|:---|:----------|-------|
+|`data_as_headers`|boolean|Send post_vars as request headers instead of body|False|
+|`token_cookie_mappings`|List of Dict|Map tokens in response body to session cookies|[]|
+|`secret_prompt_mappings`|Dict|Prompt for secret_post_vars with more descriptive names|{}|
+
 Example:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -217,6 +217,42 @@ In this example, the user would be prompted to enter a value for "password" and,
   "password": "my_password"
 }
 ```
+Additional `external_auth` settings for providers that require non standard communication pattern
+|Key|Type|Description|Default|
+|---|----|-----------|-------|
+|data_as_headers|boolean|Send post_vars as request headers instead of body|False|
+|token_cookie_mappings|List of Dict|Map tokens in response body to session cookies|[]|
+|secret_prompt_mappings|Dict|Prompt for secret_post_vars with more descriptive names|
+Example:
+
+```json
+
+  {
+    "name": "my_host",
+    "graphql_url": "https://hostname/v1/graphql",
+    "gateway_url": "https://hostname/gateway",
+    "username": "my_username",
+    "external_auth": {
+      "auth_url": "https://auth_service/route",
+      "data_as_headers": true,
+      "static_post_vars": {
+        "username": "my_username"
+      },
+      "secret_post_vars": [
+        "x-password"
+      ],
+      "token_cookie_mappings": [
+        {
+          "key": "token_name_key",
+          "value": "token_value_key"
+        }
+      ],
+      "secret_prompt_mappings": {
+        "x-password": "Password"
+      }
+    }
+  }
+```
 
 #### Using a Hasura Admin Secret
 


### PR DESCRIPTION
We ran into a need where an external auth provider expects credential in the request headers instead of body and the auth token is returned in the body instead of a cookie. This PR adds three external auth options:
- `data_as_headers`
- `token_cookie_mappings`
- `secret_prompt_mappings`

These are made to be optional and the `authenticate_with_external` would retain existing behaviors when these options are not defined.

There is one functional change to `start_session_from_configuration` to change how auth tokens are retrieved when external auth is enabled. It has been changed from a direct authentication against Aerie gateway, which would not work if the app is fully delegating authentication to an external provider, to a new validateSSO function that validates externally authenticated sessions against Aerie gateway.