### PR TITLE
Remove testpypi from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,8 @@ jobs:
         run: |
           python3 -m pip install poetry
       - name: Build for release
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           poetry build --clean
-      - name: Build local version
-        if: ${{!startsWith(github.ref, 'refs/tags/v')}}
-        run: |
-          poetry build --clean --config-settings local-version=$(git rev-parse --short HEAD)
       - name: Store distribution
         uses: actions/upload-artifact@v4
         with:
@@ -58,28 +53,3 @@ jobs:
         path: dist/
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish to TestPyPI
-    if: ${{(github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/tags/v')}}
-    needs:
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: test-pypi-publish
-      url: https://test.pypi.org/p/aerie-cli
-
-    permissions:
-      id-token: write
-
-    steps:
-    - name: Download distributions
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
...turns out it doesn't like getting multiple pushes of the `0.0.0-dev0` tag _or_ local versions.